### PR TITLE
Fix docstring typo

### DIFF
--- a/bkt.py
+++ b/bkt.py
@@ -18,7 +18,7 @@ class HLD(bt.SignalStrategy):
 class MyStrategy(bt.Strategy):
 
     def log(self, txt, dt=None):
-        ''' Logging function fot this strategy'''
+        ''' Logging function for this strategy'''
         dt = dt or self.datas[0].datetime.date(0)
         print('%s, %s' % (dt.isoformat(), txt))
 


### PR DESCRIPTION
## Summary
- correct a typo in `MyStrategy.log` docstring

## Testing
- `grep -n "Logging function" -n bkt.py`

------
https://chatgpt.com/codex/tasks/task_e_685703eeb8b88326a80267d7a44fcf1f