### PR TITLE
Handle yfinance download failures

### DIFF
--- a/fetch_stock.py
+++ b/fetch_stock.py
@@ -1,14 +1,30 @@
+import logging
 import yfinance as yf
 
-def fetch_stock(symbol, start_date=0, end_date=0, period='1mo'):
-    if start_date and end_date:
-        hourly_data = yf.download(symbol, interval='1h', start=start_date, end=end_date)
-        daily_data = yf.download(symbol, interval='1d', start=start_date, end=end_date)
-    else:
-        hourly_data = yf.download(symbol, interval='1h', period=period)
-        daily_data = yf.download(symbol, interval='1d', period=period)
-    
-    hourly_data.reset_index(inplace=True)
-    daily_data.reset_index(inplace=True)
+logging.basicConfig(level=logging.INFO)
 
-    return hourly_data,daily_data
+def fetch_stock(symbol, start_date=0, end_date=0, period="1mo"):
+    try:
+        if start_date and end_date:
+            hourly_data = yf.download(
+                symbol, interval="1h", start=start_date, end=end_date
+            )
+            daily_data = yf.download(
+                symbol, interval="1d", start=start_date, end=end_date
+            )
+        else:
+            hourly_data = yf.download(symbol, interval="1h", period=period)
+            daily_data = yf.download(symbol, interval="1d", period=period)
+
+        if hourly_data.empty or daily_data.empty:
+            logging.warning(f"No data returned for {symbol}")
+            return None, None
+
+        hourly_data.reset_index(inplace=True)
+        daily_data.reset_index(inplace=True)
+
+        return hourly_data, daily_data
+
+    except Exception as e:
+        logging.warning(f"Failed to download data for {symbol}: {e}")
+        return None, None

--- a/open_close.py
+++ b/open_close.py
@@ -1,10 +1,13 @@
 import argparse
+import logging
 import pandas as pd
 import matplotlib.pyplot as plt
 from fetch_stock import fetch_stock
 from analyze_stock import analyze_stock
 from plot_stock import plot_stock
 from matplotlib.backends.backend_pdf import PdfPages
+
+logging.basicConfig(level=logging.INFO)
 
 def main():
     parser = argparse.ArgumentParser(description='Analyze stock data for opening and closing gaps.')
@@ -35,6 +38,10 @@ def main():
                 hourly_data, daily_data = fetch_stock(symbol, start_date=start_date, end_date=end_date)
             else:
                 hourly_data, daily_data = fetch_stock(symbol, period=args.period)
+
+            if hourly_data is None or daily_data is None:
+                logging.warning(f"Skipping {symbol} due to download failure")
+                continue
 
             print(f"Stock data info for {symbol}:")
             print(hourly_data)


### PR DESCRIPTION
## Summary
- add logging and error handling to `fetch_stock`
- skip plotting if a symbol download fails in `open_close`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68571d2131748326937459c6e46de30e