### PR TITLE
Update morning_range to use fetch_stock

### DIFF
--- a/fetch_stock.py
+++ b/fetch_stock.py
@@ -3,17 +3,31 @@ import yfinance as yf
 
 logging.basicConfig(level=logging.INFO)
 
-def fetch_stock(symbol, start_date=0, end_date=0, period="1mo"):
+def fetch_stock(symbol, start_date=0, end_date=0, period="1mo", interval="1h"):
+    """Return intraday and daily data for ``symbol`` using *yfinance*.
+
+    Parameters
+    ----------
+    symbol : str
+        Ticker symbol to download.
+    start_date, end_date : datetime-like, optional
+        If provided, data is fetched between these dates.  When omitted,
+        ``period`` is used instead.
+    period : str, default ``"1mo"``
+        Period string understood by :func:`yfinance.download`.
+    interval : str, default ``"1h"``
+        Interval for intraday data. Daily data is always downloaded at ``1d``.
+    """
     try:
         if start_date and end_date:
             hourly_data = yf.download(
-                symbol, interval="1h", start=start_date, end=end_date
+                symbol, interval=interval, start=start_date, end=end_date
             )
             daily_data = yf.download(
                 symbol, interval="1d", start=start_date, end=end_date
             )
         else:
-            hourly_data = yf.download(symbol, interval="1h", period=period)
+            hourly_data = yf.download(symbol, interval=interval, period=period)
             daily_data = yf.download(symbol, interval="1d", period=period)
 
         if hourly_data.empty or daily_data.empty:


### PR DESCRIPTION
## Summary
- streamline morning_range intraday data retrieval
- extend `fetch_stock` with configurable interval and use it

## Testing
- `python3 -m py_compile fetch_stock.py morning_range.py`


------
https://chatgpt.com/codex/tasks/task_e_6857255c4f3c8326a36120ca75f90f73