### PR TITLE
Fix timezone handling for morning range

### DIFF
--- a/fetch_stock.py
+++ b/fetch_stock.py
@@ -1,5 +1,6 @@
 import logging
 import yfinance as yf
+import pandas as pd
 
 logging.basicConfig(level=logging.INFO)
 
@@ -33,6 +34,11 @@ def fetch_stock(symbol, start_date=0, end_date=0, period="1mo", interval="1h"):
         if hourly_data.empty or daily_data.empty:
             logging.warning(f"No data returned for {symbol}")
             return None, None
+
+        if isinstance(hourly_data.columns, pd.MultiIndex):
+            hourly_data.columns = hourly_data.columns.get_level_values(0)
+        if isinstance(daily_data.columns, pd.MultiIndex):
+            daily_data.columns = daily_data.columns.get_level_values(0)
 
         hourly_data.reset_index(inplace=True)
         daily_data.reset_index(inplace=True)

--- a/morning_range.py
+++ b/morning_range.py
@@ -17,9 +17,9 @@ def fetch_intraday(
         return pd.DataFrame()
 
     if "Datetime" in data.columns:
-        idx = pd.to_datetime(data["Datetime"], errors="coerce")
+        idx = pd.DatetimeIndex(pd.to_datetime(data["Datetime"], errors="coerce"))
     else:
-        idx = pd.to_datetime(data.index, errors="coerce")
+        idx = pd.DatetimeIndex(pd.to_datetime(data.index, errors="coerce"))
 
     if idx.tz is None:
         idx = idx.tz_localize("UTC")


### PR DESCRIPTION
## Summary
- ensure yfinance data has single-level columns
- convert datetime series to timezone-aware index

## Testing
- `python morning_range.py SPY --start 06-16-2025 --end 06-19-2025`

------
https://chatgpt.com/codex/tasks/task_e_685728562090832691ff99cd82a094c5