### PR TITLE
Add open range percentage tracking and plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ The analysis scripts now include a data point for the overnight gap
 between the previous day's close (4 PM) and the next day's open at
 9:30 AM.  This is reported as `PrevClose_Open_Gap` (absolute) and
 `PrevClose_Open_Gap_Pct` (percentage).
+
+The opening range (the first hour high/low difference) is reported as
+`Open_Range_Pct` relative to the day's open with a running total
+`Cumulative_Open_Range_Pct`.

--- a/analyze_stock.py
+++ b/analyze_stock.py
@@ -52,6 +52,8 @@ def analyze_stock(hourly_data, daily_data):
     daily_data = daily_data.merge(first_hour_data[['Date', 'First_Hour_Open', 'First_Hour_Close', 'First_Hour_High', 'First_Hour_Low']], left_on='Date', right_on='Date', how='left')
 
     daily_data['First_Hour_Range'] = daily_data['First_Hour_High'] - daily_data['First_Hour_Low']
+    daily_data['Open_Range_Pct'] = daily_data['First_Hour_Range'] / daily_data['Open'] * 100
+    daily_data['Cumulative_Open_Range_Pct'] = daily_data['Open_Range_Pct'].cumsum()
     daily_data['First_Hour_Close_Change'] = (daily_data['First_Hour_Close'] - daily_data['First_Hour_Open']) / daily_data['First_Hour_Open'] * 100
 
     conditions = [

--- a/plot_stock.py
+++ b/plot_stock.py
@@ -11,9 +11,9 @@ def plot_stock(symbol, daily_data, hourly_data):
     norm_volume = (hourly_data['Volume'] - hourly_data['Volume'].min()) / (hourly_data['Volume'].max() - hourly_data['Volume'].min())
     sizes = min_size + norm_volume * (max_size - min_size)
 
-    # Create a figure with 2 subplots, the first one being larger
-    fig, axs = plt.subplots(2, 1, figsize=(12, 12))
-    grid_spec = fig.add_gridspec(2, 1, height_ratios=[3, 1])
+    # Create a figure with 3 subplots, the first one being larger
+    fig, axs = plt.subplots(3, 1, figsize=(12, 14))
+    grid_spec = fig.add_gridspec(3, 1, height_ratios=[3, 1, 1])
 
     # Plot daily open prices as a line on the first subplot
     ax1 = fig.add_subplot(grid_spec[0])
@@ -67,6 +67,16 @@ def plot_stock(symbol, daily_data, hourly_data):
 
     # Add a legend to the second subplot
     ax2.legend()
+
+    # Plot opening range percentage on the third subplot
+    ax3 = fig.add_subplot(grid_spec[2])
+    ax3.plot(daily_data['Date'], daily_data['Open_Range_Pct'], label='Open Range %', color='brown')
+    ax3.plot(daily_data['Date'], daily_data['Cumulative_Open_Range_Pct'], label='Cumulative Open Range %', color='darkorange', linestyle='--')
+    ax3.set_title(f'Opening Range % for {symbol}')
+    ax3.set_xlabel('Date')
+    ax3.set_ylabel('Open Range %')
+    ax3.tick_params(axis='x', rotation=45)
+    ax3.legend()
 
     # Ensure layout is tight
     plt.tight_layout()


### PR DESCRIPTION
## Summary
- compute open range % of daily open in `analyze_stock`
- plot daily and cumulative open range percentage in `plot_stock`
- document new data columns in README

## Testing
- `python -m py_compile analyze_stock.py plot_stock.py open_close.py`

------
https://chatgpt.com/codex/tasks/task_e_685825efb14c83268d6139c16f1f419f