### PR TITLE
Add configurable opening range duration

### DIFF
--- a/open_range_break.py
+++ b/open_range_break.py
@@ -49,8 +49,13 @@ def fetch_intraday(
     return data
 
 
-def analyze_open_range(df: pd.DataFrame) -> tuple[int, int, int, int, int, dict]:
+def analyze_open_range(
+    df: pd.DataFrame, open_range_minutes: int = 30
+) -> tuple[int, int, int, int, int, dict]:
     """Analyze opening range breaks for each trading day.
+
+    ``open_range_minutes`` specifies how many minutes after 9:30am EST make up
+    the opening range.
 
     Returns tuple of ``(total_days, broke_low_first, broke_low_then_high,
     broke_high_first, broke_high_then_low, high_before_low_map)`` where
@@ -70,8 +75,12 @@ def analyze_open_range(df: pd.DataFrame) -> tuple[int, int, int, int, int, dict]
     broke_high_then_low = 0
     high_before_low_map: dict[pd.Timestamp, bool] = {}
 
+    open_end = (
+        pd.Timestamp("09:30") + timedelta(minutes=open_range_minutes)
+    ).strftime("%H:%M")
+
     for date, day_df in grouped:
-        morning = day_df.between_time("09:30", "10:00")
+        morning = day_df.between_time("09:30", open_end)
         if morning.empty:
             continue
         or_high = morning["High"].max()
@@ -117,7 +126,9 @@ def analyze_open_range(df: pd.DataFrame) -> tuple[int, int, int, int, int, dict]
     )
 
 
-def calculate_open_range_pct(df: pd.DataFrame) -> pd.Series:
+def calculate_open_range_pct(
+    df: pd.DataFrame, open_range_minutes: int = 30
+) -> pd.Series:
     """Return a Series of opening range percentages indexed by date."""
     if df.empty:
         return pd.Series(dtype=float)
@@ -126,8 +137,11 @@ def calculate_open_range_pct(df: pd.DataFrame) -> pd.Series:
     grouped = df.groupby(df.index.date)
 
     pct_values = {}
+    open_end = (
+        pd.Timestamp("09:30") + timedelta(minutes=open_range_minutes)
+    ).strftime("%H:%M")
     for date, day_df in grouped:
-        morning = day_df.between_time("09:30", "10:00")
+        morning = day_df.between_time("09:30", open_end)
         if morning.empty:
             continue
         or_high = morning["High"].max()
@@ -150,6 +164,12 @@ def main() -> None:
         default=None,
         help="Data interval (default determined automatically)",
     )
+    parser.add_argument(
+        "--range",
+        type=int,
+        default=30,
+        help="Opening range in minutes (default 30)",
+    )
     args = parser.parse_args()
 
     if args.start and args.end:
@@ -164,7 +184,7 @@ def main() -> None:
         df = fetch_intraday(args.ticker, start, end, interval=interval)
 
     # Calculate open range percentages for plotting
-    or_pct = calculate_open_range_pct(df)
+    or_pct = calculate_open_range_pct(df, open_range_minutes=args.range)
 
     (
         total,
@@ -173,7 +193,7 @@ def main() -> None:
         high_first,
         high_then_low,
         high_before_low_map,
-    ) = analyze_open_range(df)
+    ) = analyze_open_range(df, open_range_minutes=args.range)
 
     print(f"Total days analyzed: {total}")
     print(f"Broke low before high: {low_first} ({(low_first/total*100 if total else 0):.2f}%)")


### PR DESCRIPTION
## Summary
- add `--range` argument to open_range_break
- allow `analyze_open_range` and `calculate_open_range_pct` to take range minutes

## Testing
- `python -m py_compile open_range_break.py`

------
https://chatgpt.com/codex/tasks/task_e_68583f652b4083269578594326fc8d38