### PR TITLE
Update open_range_break default behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@ reads tickers from `portfolios/M9.txt` which might contain:
 ```
 AMZN MSFT AAPL NVDA META GOOG TSLA MU AVGO
 ```
+
+If you omit both `--period` and `--start`, `open_range_break.py` will
+analyze a single day automatically. When run before 9:30 AM US/Eastern it
+uses the previous trading day; otherwise it uses the current day.

--- a/open_range_break.py
+++ b/open_range_break.py
@@ -246,7 +246,7 @@ def main() -> None:
         nargs="+",
         help="Ticker symbol or a list of symbols separated by spaces",
     )
-    group = parser.add_mutually_exclusive_group(required=True)
+    group = parser.add_mutually_exclusive_group(required=False)
     group.add_argument("--period", help="Period string for yfinance (e.g. 1mo, 6mo)")
     group.add_argument("--start", help="Start date YYYY-MM-DD")
     parser.add_argument("--end", help="End date YYYY-MM-DD")
@@ -269,16 +269,21 @@ def main() -> None:
     super_total_profit = 0
 
     for ticker in tickers:
-        if args.start and args.end:
+        if args.start:
             start = pd.to_datetime(args.start)
-            end = pd.to_datetime(args.end)
-            interval = args.interval or choose_yfinance_interval(start=start, end=end)
-            df = fetch_intraday(ticker, start, end, interval=interval)
-        else:
+            end = pd.to_datetime(args.end) if args.end else start
+        elif args.period:
             end = pd.to_datetime(args.end) if args.end else None
             start, end = period_to_start_end(args.period, end=end)
-            interval = args.interval or choose_yfinance_interval(start=start, end=end)
-            df = fetch_intraday(ticker, start, end, interval=interval)
+        else:
+            now = pd.Timestamp.now(tz="US/Eastern")
+            nine_thirty = pd.Timestamp("09:30", tz="US/Eastern").time()
+            if now.time() < nine_thirty:
+                start = end = (now - pd.Timedelta(days=1)).normalize()
+            else:
+                start = end = now.normalize()
+        interval = args.interval or choose_yfinance_interval(start=start, end=end)
+        df = fetch_intraday(ticker, start, end, interval=interval)
 
         # Calculate open range percentages for plotting
         or_pct = calculate_open_range_pct(df, open_range_minutes=args.range)
@@ -293,14 +298,13 @@ def main() -> None:
             f"  Days closed higher than open: {results.closed_higher_than_open} "
             f"({(results.closed_higher_than_open / results.total_days * 100 if results.total_days else 0):.2f}%)"
         )
-"""        print(f"  Broke low before high: {results.broke_low_first} ({(results.broke_low_first / results.total_days * 100 if results.total_days else 0):.2f}%)")
-        print(f"  Broke low then above high: {results.broke_low_then_high} ({(results.broke_low_then_high / results.total_days * 100 if results.total_days else 0):.2f}%)")
-        print(f"  Broke high before low: {results.broke_high_first} ({(results.broke_high_first / results.total_days * 100 if results.total_days else 0):.2f}%)")
-        print(f"  Broke high then low: {results.broke_high_then_low} ({(results.broke_high_then_low / results.total_days * 100 if results.total_days else 0):.2f}%)")
-        print(f"  OR high before low: {results.or_high_before_low} ({(results.or_high_before_low / results.total_days * 100 if results.total_days else 0):.2f}%)")
-        print(f"  OR low before high: {results.or_low_before_high} ({(results.or_low_before_high / results.total_days * 100 if results.total_days else 0):.2f}%)")
-        print(f"  Close higher than open when OR low before high: {results.low_before_high_close_up} ({(results.low_before_high_close_up / results.or_low_before_high * 100 if results.or_low_before_high else 0):.2f}%)")
-"""
+#        print(f"  Broke low before high: {results.broke_low_first} ({(results.broke_low_first / results.total_days * 100 if results.total_days else 0):.2f}%)")
+#        print(f"  Broke low then above high: {results.broke_low_then_high} ({(results.broke_low_then_high / results.total_days * 100 if results.total_days else 0):.2f}%)")
+#        print(f"  Broke high before low: {results.broke_high_first} ({(results.broke_high_first / results.total_days * 100 if results.total_days else 0):.2f}%)")
+#        print(f"  Broke high then low: {results.broke_high_then_low} ({(results.broke_high_then_low / results.total_days * 100 if results.total_days else 0):.2f}%)")
+#        print(f"  OR high before low: {results.or_high_before_low} ({(results.or_high_before_low / results.total_days * 100 if results.total_days else 0):.2f}%)")
+#        print(f"  OR low before high: {results.or_low_before_high} ({(results.or_low_before_high / results.total_days * 100 if results.total_days else 0):.2f}%)")
+#        print(f"  Close higher than open when OR low before high: {results.low_before_high_close_up} ({(results.low_before_high_close_up / results.or_low_before_high * 100 if results.or_low_before_high else 0):.2f}%)")
         print(
             f"  Close higher than open when OR high before low: {results.high_before_low_close_up} "
             f"({(results.high_before_low_close_up / results.or_high_before_low * 100 if results.or_high_before_low else 0):.2f}%)"


### PR DESCRIPTION
## Summary
- make `--period`/`--start` optional in `open_range_break.py`
- default to analyzing yesterday before 9:30am or today after 9:30am
- document new behaviour in README

## Testing
- `python3 -m py_compile open_range_break.py stock_functions.py`
- `python3 open_range_break.py -h | head -n 20`
- `pip install matplotlib`

------
https://chatgpt.com/codex/tasks/task_e_68594e353da88326b32f4f0cc0f42d25