### PR TITLE
Update weekend handling for open_range_break

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,5 @@ AMZN MSFT AAPL NVDA META GOOG TSLA MU AVGO
 
 If you omit both `--period` and `--start`, `open_range_break.py` will
 analyze a single day automatically. When run before 9:30 AM US/Eastern it
-uses the previous trading day; otherwise it uses the current day.
+uses the previous trading day (adjusting for weekends); otherwise it uses
+the current day.

--- a/open_range_break.py
+++ b/open_range_break.py
@@ -279,7 +279,12 @@ def main() -> None:
             now = pd.Timestamp.now(tz="US/Eastern")
             nine_thirty = pd.Timestamp("09:30", tz="US/Eastern").time()
             if now.time() < nine_thirty:
-                start = end = (now - pd.Timedelta(days=1)).normalize()
+                start = (now - pd.Timedelta(days=1)).normalize()
+                if start.dayofweek == 5:  # Saturday -> use previous Friday
+                    start -= pd.Timedelta(days=1)
+                elif start.dayofweek == 6:  # Sunday -> use previous Friday
+                    start -= pd.Timedelta(days=2)
+                end = start
             else:
                 start = end = now.normalize()
         interval = args.interval or choose_yfinance_interval(start=start, end=end)


### PR DESCRIPTION
## Summary
- handle weekends when automatically selecting a date before market open
- document new weekend logic in README

## Testing
- `python -m py_compile open_range_break.py`

------
https://chatgpt.com/codex/tasks/task_e_6859506283d483268baf8407f105f12d