### PR TITLE
Add caching to fetch_stock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Desktop.ini
 *.csv
 .~lock*
 API_KEY.txt
+yfinance_cache/

--- a/fetch_stock.py
+++ b/fetch_stock.py
@@ -1,8 +1,24 @@
 import logging
-import yfinance as yf
+import hashlib
+from pathlib import Path
+
 import pandas as pd
+import yfinance as yf
 
 logging.basicConfig(level=logging.INFO)
+
+# Directory used for caching yfinance responses
+CACHE_DIR = Path(__file__).resolve().parent / "yfinance_cache"
+CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+def _cache_path(symbol, start_date, end_date, period, interval):
+    """Return the cache file path for a given set of yfinance arguments."""
+    key = f"{symbol}_{start_date}_{end_date}_{period}_{interval}"
+    h = hashlib.md5(key.encode()).hexdigest()
+    sub = CACHE_DIR / h[:2]
+    sub.mkdir(parents=True, exist_ok=True)
+    return sub / f"{h}.pkl"
+
 
 def fetch_stock(symbol, start_date=0, end_date=0, period="1mo", interval="1h"):
     """Return intraday and daily data for ``symbol`` using *yfinance*.
@@ -20,6 +36,27 @@ def fetch_stock(symbol, start_date=0, end_date=0, period="1mo", interval="1h"):
         Interval for intraday data. Daily data is always downloaded at ``1d``.
     """
     try:
+        cache_file = _cache_path(symbol, start_date, end_date, period, interval)
+
+        # Do not cache if the requested end date is today
+        cache_enabled = True
+        if end_date:
+            try:
+                end_dt = pd.to_datetime(end_date)
+                if end_dt.tzinfo is None:
+                    end_dt = end_dt.tz_localize("UTC")
+                if end_dt.normalize() == pd.Timestamp.utcnow().normalize():
+                    cache_enabled = False
+            except Exception:
+                pass
+
+        if cache_enabled and cache_file.exists():
+            try:
+                data = pd.read_pickle(cache_file)
+                return data
+            except Exception as e:
+                logging.warning(f"Failed to read cache {cache_file}: {e}")
+
         if start_date and end_date:
             data = yf.download(
                 symbol, interval=interval, start=start_date, end=end_date
@@ -35,6 +72,12 @@ def fetch_stock(symbol, start_date=0, end_date=0, period="1mo", interval="1h"):
             data.columns = data.columns.get_level_values(0)
 
         data.reset_index(inplace=True)
+
+        if cache_enabled:
+            try:
+                data.to_pickle(cache_file)
+            except Exception as e:
+                logging.warning(f"Failed to write cache {cache_file}: {e}")
 
         return data
 


### PR DESCRIPTION
## Summary
- add a cache directory for yfinance responses
- compute MD5 hash of request parameters to use as cache key
- skip caching when the request ends on the current date
- read/write cached data using pickle for fidelity
- ignore cache directory in version control

## Testing
- `python -m py_compile fetch_stock.py`
- `python - <<'PY'
from fetch_stock import fetch_stock, CACHE_DIR
import os, shutil
shutil.rmtree(CACHE_DIR)
CACHE_DIR.mkdir(parents=True)
print('First call (downloads)')
fetch_stock('AAPL', period='5d', interval='1h')
print('Cache files', sum(len(f) for _,_,f in os.walk(CACHE_DIR)))
print('Second call (uses cache)')
fetch_stock('AAPL', period='5d', interval='1h')
print('Cache files', sum(len(f) for _,_,f in os.walk(CACHE_DIR)))
PY

------
https://chatgpt.com/codex/tasks/task_e_6859a3b1fa788326b3675dfe8bb49464