### PR TITLE
Use gain/loss helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ If you omit both `--period` and `--start`, `open_range_break.py` will
 analyze a single day automatically. When run before 9:30 AM US/Eastern it
 uses the previous trading day (adjusting for weekends); otherwise it uses
 the current day.
+
+The script also provides `--profit-pct` and `--loss-pct` options to
+control the intraday profit target and stop loss percentages when a trade
+is taken after the opening range.


### PR DESCRIPTION
## Summary
- support `--loss-pct` and `--profit-pct` options in `open_range_break.py`
- integrate `determine_gain_or_loss` for trade exit logic
- document new CLI options

## Testing
- `python -m py_compile open_range_break.py`
- `python open_range_break.py --help` *(fails: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_6859afe456c8832686ea8cf0c5396559