### PR TITLE
Add CSV export to open_range_break

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,5 @@ the current day.
 The script also provides `--profit-pct` and `--loss-pct` options to
 control the intraday profit target and stop loss percentages when a trade
 is taken after the opening range.
+
+When the analysis completes, all trades are written to `./output/<timestamp>_trades.csv` and a per-ticker summary is saved to `./output/<timestamp>_tickers.csv`. The summary lists the total number of trades, the percentage of profitable trades, and the cumulative profit for each ticker.


### PR DESCRIPTION
## Summary
- export trade details and per-ticker summaries in open_range_break
- document new CSV output files in README

## Testing
- `python -m py_compile open_range_break.py`

------
https://chatgpt.com/codex/tasks/task_e_6859d61fe7588326934d7586b57a95cf