### PR TITLE
Update stock_fetch end date logic

### DIFF
--- a/fetch_stock.py
+++ b/fetch_stock.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pandas as pd
 import yfinance as yf
+from datetime import datetime
 
 logging.basicConfig(level=logging.INFO)
 
@@ -36,6 +37,15 @@ def fetch_stock(symbol, start_date=0, end_date=0, period="1mo", interval="1h"):
         Interval for intraday data. Daily data is always downloaded at ``1d``.
     """
     try:
+        if end_date:
+            try:
+                end_dt = pd.to_datetime(end_date)
+                now = pd.Timestamp.now(tz=end_dt.tzinfo) if end_dt.tzinfo else pd.Timestamp.now()
+                if end_dt.normalize() == now.normalize() and end_dt.time() == datetime.min.time():
+                    end_date = now
+            except Exception:
+                pass
+
         cache_file = _cache_path(symbol, start_date, end_date, period, interval)
 
         # Do not cache if the requested end date is today and the current time


### PR DESCRIPTION
## Summary
- adjust handling of end date in `fetch_stock`
  - if the provided end date is today and includes no specific time, default to the current time
- import `datetime` for new logic

## Testing
- `python -m py_compile fetch_stock.py open_range_break.py open_close.py portfolio_compare.py`


------
https://chatgpt.com/codex/tasks/task_e_685a9a3b7140832687cb9870e64dbbd7