### PR TITLE
Add profit_or_loss column to trades CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ control the intraday profit target and stop loss percentages when a trade
 is taken after the opening range.
 
 When the analysis completes, all trades are written to `./output/<timestamp>_trades.csv` and a per-ticker summary is saved to `./output/<timestamp>_tickers.csv`. The summary lists the total number of trades, the percentage of profitable trades, and the cumulative profit for each ticker.
+The trades file includes a `profit_or_loss` column after `sell_time` showing whether each trade hit the profit target, stop loss, or closed at the end of the day.

--- a/fetch_stock.py
+++ b/fetch_stock.py
@@ -41,7 +41,12 @@ def fetch_stock(symbol, start_date=0, end_date=0, period="1mo", interval="1h"):
                 end_dt = pd.to_datetime(end_date)
                 now = pd.Timestamp.now(tz=end_dt.tzinfo) if end_dt.tzinfo else pd.Timestamp.now()
                 if end_dt.normalize() == now.normalize():
-                    end_date = now - pd.Timedelta(minutes=5)
+                    now_est = now.tz_convert("US/Eastern") if now.tzinfo else now.tz_localize("UTC").tz_convert("US/Eastern")
+                    four_pm_est = now_est.normalize() + pd.Timedelta(hours=16)
+                    if now_est >= four_pm_est:
+                        end_date = four_pm_est
+                    else:
+                        end_date = now - pd.Timedelta(minutes=5)
             except Exception:
                 pass
 

--- a/open_range_break.py
+++ b/open_range_break.py
@@ -526,6 +526,7 @@ def main() -> None:
             "profit",
             "buy_time",
             "sell_time",
+            "result",
             "minutes",
         ]
         trades_df = trades_df[[c for c in desired_cols if c in trades_df.columns]]
@@ -546,6 +547,9 @@ def main() -> None:
         for col in ["buy_time", "sell_time"]:
             if col in trades_df.columns:
                 trades_df[col] = pd.to_datetime(trades_df[col]).dt.strftime("%H:%M")
+
+        if "result" in trades_df.columns:
+            trades_df = trades_df.rename(columns={"result": "profit_or_loss"})
 
         trades_df.to_csv(trades_path, index=False)
         if args.trades:


### PR DESCRIPTION
## Summary
- include the trade result in the generated trades CSV
- mention the new `profit_or_loss` column in README
- set the fetch end date to 4pm EST if today is past market close

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b0f499ebc8326b03881f9e7f22f8a