### PR TITLE
Add top profit metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,8 @@ The script also provides `--profit-pct` and `--loss-pct` options to
 control the intraday profit target and stop loss percentages when a trade
 is taken after the opening range.
 
-When the analysis completes, all trades are written to `./output/<timestamp>_trades.csv` and a per-ticker summary is saved to `./output/<timestamp>_tickers.csv`. The summary lists the total number of trades, the percentage of profitable trades, and the cumulative profit for each ticker.
+When the analysis completes, all trades are written to `./output/<timestamp>_trades.csv` and a per-ticker summary is saved to `./output/<timestamp>_tickers.csv`. The summary lists the total number of trades, the percentage of profitable trades, and the cumulative profit for each ticker. It also includes `total_top_profit`, the sum of potential profits based on each trade's peak price.
 The trades file includes a `profit_or_loss` column after `sell_time` showing whether each trade hit the profit target, stop loss, or closed at the end of the day.
+Each trade also reports `top_profit`, the highest price reached before the trade exited.
+Pass `--trades` to print each trade in the terminal. Use `--tickers` to display
+the per-ticker summary in an ASCII table after the trades.


### PR DESCRIPTION
## Summary
- compute the maximum price reachable before a trade exits
- include `top_profit` in each trade's record and table output
- document the new `top_profit` column
- add `total_top_profit` to per-ticker summaries

## Testing
- `python -m py_compile open_range_break.py`


------
https://chatgpt.com/codex/tasks/task_e_685b17e9f8648326a6c03535f9cd024e