### PR TITLE
Fix open range error when near closing data missing

### DIFF
--- a/open_range_break.py
+++ b/open_range_break.py
@@ -160,6 +160,11 @@ def analyze_open_range(
         or_low_time = morning["Low"].idxmin()
         open_price = morning.iloc[0]["Open"]
         close_price = day_df.iloc[-1]["Close"]
+        if near_closing.empty:
+            # Skip the day if there is no data immediately after the opening
+            # range. Attempting to access ``near_closing.iloc[0]`` would raise
+            # ``IndexError`` otherwise.
+            continue
         after_or_price = near_closing.iloc[0]["Open"]
         after_or_time = near_closing.index[0]
 


### PR DESCRIPTION
## Summary
- handle cases where there is no data immediately after the opening range to avoid `IndexError`

## Testing
- `python -m py_compile open_range_break.py`

------
https://chatgpt.com/codex/tasks/task_e_685b4dd15bec832692e6dbd4ae3c310b