### PR TITLE
Implement output-tickers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,6 @@ trade. `--filter-offset` multiplies the open price used in that check.
 
 When the analysis completes, all trades are written to `./output/<timestamp>_trades.csv` and a per-ticker summary is saved to `./output/<timestamp>_tickers.csv`. The summary lists the total number of trades, the percentage of profitable trades, and the cumulative profit for each ticker. It also includes `total_top_profit`, the sum of potential profits based on each trade's peak price.
 The trades file includes a `profit_or_loss` column after `sell_time` showing whether each trade hit the profit target, stop loss, or closed at the end of the day.
-Each trade also reports `top_profit`, the highest price reached before the trade exited.
-Pass `--trades` to print each trade in the terminal. Use `--tickers` to display
-the per-ticker summary in an ASCII table after the trades.
+Each trade also reports `top_profit`, the percent gain from entry to the highest price reached before exiting.
+Pass `--output-trades` to print each trade in the terminal. Use `--tickers` or
+`--output-tickers` to display the per-ticker summary in an ASCII table after the trades.


### PR DESCRIPTION
## Summary
- add `--output-tickers` option in backtest to display ticker metrics
- compute and report average trade time per ticker
- rename `--trades` option to `--output-trades`
- output top profit in trades as percent difference

## Testing
- `python -m py_compile backtest.py`
- `python backtest.py AAPL --period 1d --output-tickers --output-trades` *(fails: No module named 'matplotlib')*


------
https://chatgpt.com/codex/tasks/task_e_685db15fad4c8326a445fc3f67fcb730