### PR TITLE
Order ticker summary by profit

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,5 @@ The trades file includes a `profit_or_loss` column after `sell_time` showing whe
 Each trade also reports `top_profit`, the percent gain from entry to the highest price reached before exiting.
 Pass `--output-trades` to print each trade in the terminal. Use `--tickers` or
 `--output-tickers` to display the per-ticker summary in an ASCII table after the trades.
+The summary table is ordered by `total_profit` descending and entries
+with profits less than the value passed to `--min-profit` are omitted.

--- a/backtest.py
+++ b/backtest.py
@@ -638,9 +638,16 @@ def main() -> None:
 
     if ticker_rows:
         tickers_df = pd.DataFrame(ticker_rows)
+
+        # Order by total profit descending and apply --min-profit filter
+        tickers_df = tickers_df.sort_values(by="total_profit", ascending=False)
+        if args.min_profit is not None:
+            tickers_df = tickers_df[tickers_df["total_profit"] > args.min_profit]
+
         for col in ["trade_success_pct", "total_profit", "total_top_profit", "avg_trade_time"]:
             if col in tickers_df.columns:
                 tickers_df[col] = tickers_df[col].map(lambda x: f"{x:.2f}")
+
         tickers_df.to_csv(tickers_path, index=False)
         if args.tickers or args.output_tickers:
             if tabulate:


### PR DESCRIPTION
## Summary
- filter tickers by `--min-profit` and sort them by `total_profit`
- document the ticker table behavior in README

## Testing
- `python -m py_compile backtest.py`

------
https://chatgpt.com/codex/tasks/task_e_685db636d7f4832682d44f876d81ee0e