### PR TITLE
Deduplicate tickers in backtest

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ reads tickers from `portfolios/M9.txt` which might contain:
 AMZN MSFT AAPL NVDA META GOOG TSLA MU AVGO
 ```
 
+Duplicate tickers are ignored, so the portfolio and command-line
+arguments can safely include overlapping symbols.
+
 If you omit both `--period` and `--start`, `backtest.py` will
 analyze a single day automatically. When run before 9:30 AM US/Eastern it
 uses the previous trading day (adjusting for weekends); otherwise it uses

--- a/backtest.py
+++ b/backtest.py
@@ -57,7 +57,9 @@ def expand_ticker_args(ticker_args: list[str]) -> list[str]:
                 print(f"Portfolio file not found: {path}")
         else:
             expanded.append(token)
-    return expanded
+
+    # Remove duplicates while preserving order
+    return list(dict.fromkeys(expanded))
 
 
 def fetch_intraday(


### PR DESCRIPTION
## Summary
- avoid duplicate tickers when expanding portfolio names
- document deduplication in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685dd4bda9e88326861abe5fa5607998