### PR TITLE
Add daily profit plotting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ Pass `--output-trades` to print each trade in the terminal. Use `--tickers` or
 `--output-tickers` to display the per-ticker summary in an ASCII table after the trades.
 The summary table is ordered by `total_profit` descending and entries
 with profits less than the value passed to `--min-profit` are omitted.
+Pass `--plot daily` to generate a bar chart showing the total profit of all trades for each trading day in the analyzed range.


### PR DESCRIPTION
## Summary
- update README for plotting instructions
- add `--plot` argument with new `daily` option in backtest
- plot total profit per day when `--plot daily` is used

## Testing
- `python -m py_compile backtest.py`
- `python backtest.py --help | head`

------
https://chatgpt.com/codex/tasks/task_e_685f131559d08326be41bfb1045d505d