### PR TITLE
Add total profit and top profit to daily plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,6 @@ The summary table is ordered by `total_profit` descending and entries
 with profits less than the value passed to `--min-profit` are omitted.
 Pass `--plot daily` to generate a single plot summarizing daily activity. The
 profit line appears on the left y-axis and a stacked bar chart on the right
-shows the number of profit, close, and loss trades for each day.
+shows the number of profit, close, and loss trades for each day. The plot also
+includes a third axis for total profit and a second line depicting the average
+top profit.


### PR DESCRIPTION
## Summary
- support plotting daily average top profit and total profit
- document new plot features in README

## Testing
- `python -m py_compile backtest.py`
- `python backtest.py --help`

------
https://chatgpt.com/codex/tasks/task_e_685f2d6f82788326a50372b505fc37cd