### PR TITLE
Add gap filters and prev close to backtest

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,12 @@ is taken after the opening range.
 Use `--filter` to control the relationship between the opening range
 close (Mark) and the day's open that must be satisfied before entering a
 trade. `--filter-offset` multiplies the open price used in that check.
+Additional values `GU` and `GD` limit trades to gap up or gap down days
+based on the previous close.
 
 When the analysis completes, all trades are written to `./output/<timestamp>_trades.csv` and a per-ticker summary is saved to `./output/<timestamp>_tickers.csv`. The summary lists the total number of trades, the percentage of profitable trades, and the cumulative profit for each ticker. It also includes `total_top_profit`, the sum of potential profits based on each trade's peak price.
 The trades file includes a `profit_or_loss` column after `sell_time` showing whether each trade hit the profit target, stop loss, or closed at the end of the day.
-Each trade also reports `top_profit`, the percent gain from entry to the highest price reached before exiting.
+Each trade also reports `top_profit`, the percent gain from entry to the highest price reached before exiting, and `prev_close`, the previous day's closing price.
 Pass `--output-trades` to print each trade in the terminal. Use `--tickers` or
 `--output-tickers` to display the per-ticker summary in an ASCII table after the trades.
 The summary table is ordered by `total_profit` descending and entries


### PR DESCRIPTION
## Summary
- allow `--filter` options `GU` and `GD`
- track previous day's close when analyzing trades
- output previous close in the trades CSV
- document new filters and trade column

## Testing
- `python -m py_compile backtest.py`
- `python backtest.py AAPL --start 2024-01-02 --end 2024-01-03 --filter GU` *(fails: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_685f411ca5e48326993b2bdd71e7bcab