### PR TITLE
Skip weekends in 30mMO1-3

### DIFF
--- a/30mMO1-3.py
+++ b/30mMO1-3.py
@@ -130,6 +130,9 @@ def main() -> None:
     daily_stats: list[dict[str, float | int | datetime]] = []
 
     while current <= end_date:
+        if current.weekday() >= 5:  # Skip Saturday and Sunday
+            current += timedelta(days=1)
+            continue
         lookback_start = current - timedelta(days=14)
         lookback_end = current - timedelta(days=1)
 


### PR DESCRIPTION
## Summary
- skip Saturdays and Sundays when iterating over backtest days in `30mMO1-3.py`

## Testing
- `python -m py_compile 30mMO1-3.py`
- `python -m py_compile backtest.py`

------
https://chatgpt.com/codex/tasks/task_e_68607fef6ea483269be2492591715b3c