### PR TITLE
Add ORM filter to backtest

### DIFF
--- a/30mMO1-3.py
+++ b/30mMO1-3.py
@@ -191,9 +191,11 @@ def main() -> None:
     )
     parser.add_argument(
         "--filter",
-        choices=["MO", "OM"],
         default="MO",
-        help="Trade filter (default MO)",
+        help=(
+            "Space-separated trade filters. Prefix with ! to invert. "
+            "Available filters: MO, OM, ORM"
+        ),
     )
     parser.add_argument(
         "--min-profit",

--- a/backtest.py
+++ b/backtest.py
@@ -74,9 +74,12 @@ def main() -> None:
     )
     parser.add_argument(
         "--filter",
-        choices=["MO", "OM"],
         default="MO",
-        help="Trade filter: MO for Mark > Open or OM for Open > Mark",
+        help=(
+            "Space-separated trade filters. Prefix with ! to invert. "
+            "Available filters: MO (Mark > Open), OM (Open > Mark), ORM (Buy "
+            "Price * 1.002 > Open Range High)"
+        ),
     )
     parser.add_argument(
         "--filter-offset",


### PR DESCRIPTION
## Summary
- allow new `ORM` filter in backtest CLI and predictive runner
- implement `ORM` logic in `open_range` analysis
- support multiple filters with `--filter` using `!` to invert

## Testing
- `python -m py_compile backtest.py open_range.py 30mMO1-3.py`

------
https://chatgpt.com/codex/tasks/task_e_68618562a8888326b6e5bf63087be7c0