### PR TITLE
Add console-out argument

### DIFF
--- a/30mMO1-3.py
+++ b/30mMO1-3.py
@@ -208,6 +208,11 @@ def main() -> None:
         default=-1.0,
         help="Minimum total profit to include ticker (default -1)",
     )
+    parser.add_argument(
+        "--console-out",
+        default="",
+        help="Space separated options to print to console (tickers, trades)",
+    )
     args = parser.parse_args()
 
     start_date = datetime.strptime(args.start, "%Y-%m-%d").date()
@@ -245,6 +250,7 @@ def main() -> None:
             "--min-profit",
             str(args.min_profit),
             *args.ticker_list,
+            *( ["--console-out", args.console_out] if args.console_out else [] ),
         ])
 
         df = pd.read_csv(csv_path)
@@ -295,6 +301,7 @@ def main() -> None:
             "--min-profit",
             str(args.min_profit),
             *tickers,
+            *( ["--console-out", args.console_out] if args.console_out else [] ),
         ])
 
         result_df = pd.read_csv(result_csv)

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ and `GD` (Open below previous close).
 When the analysis completes, all trades are written to `./output/<timestamp>_trades.csv` and a per-ticker summary is saved to `./output/<timestamp>_tickers.csv`. The summary lists the total number of trades, the percentage of profitable trades, and the cumulative profit for each ticker. It also includes `total_top_profit`, the sum of potential profits based on each trade's peak price.
 The trades file includes a `profit_or_loss` column after `sell_time` showing whether each trade hit the profit target, stop loss, or closed at the end of the day.
 Each trade also reports `top_profit`, the percent gain from entry to the highest price reached before exiting.
-Pass `--output-trades` to print each trade in the terminal. Use `--tickers` or
-`--output-tickers` to display the per-ticker summary in an ASCII table after the trades.
+Pass `--console-out trades` to print each trade in the terminal. Use `--tickers` or
+`--console-out tickers` to display the per-ticker summary in an ASCII table after the trades.
 The summary table is ordered by `total_profit` descending and entries
 with profits less than the value passed to `--min-profit` are omitted.
 Pass `--plot daily` to generate a single plot summarizing daily activity. The

--- a/backtest.py
+++ b/backtest.py
@@ -100,20 +100,17 @@ def main() -> None:
         help="Minimum total profit to display details (default 1.9)",
     )
     parser.add_argument(
-        "--output-trades",
-        action="store_true",
-        default=1,
-        help="Print all trades to console in an ASCII table",
+        "--console-out",
+        default="",
+        help=(
+            "Space separated options to print to console. "
+            "Use 'trades' to show all trades and 'tickers' for the per-ticker summary"
+        ),
     )
     parser.add_argument(
         "--tickers",
         action="store_true",
         help="Print per-ticker summary to console in an ASCII table",
-    )
-    parser.add_argument(
-        "--output-tickers",
-        action="store_true",
-        help="Output per-ticker metrics table to console",
     )
     parser.add_argument(
         "--plot",
@@ -307,7 +304,7 @@ def main() -> None:
             trades_df = trades_df.rename(columns={"result": "profit_or_loss"})
 
         trades_df.to_csv(trades_path, index=False)
-        if args.output_trades:
+        if "trades" in args.console_out.split():
             if tabulate:
                 print(tabulate(trades_df, headers="keys", tablefmt="grid", showindex=False))
             else:
@@ -353,7 +350,7 @@ def main() -> None:
 
 
         tickers_df.to_csv(tickers_path, index=False)
-        if args.tickers or args.output_tickers:
+        if args.tickers or "tickers" in args.console_out.split():
             if tabulate:
                 print(tabulate(tickers_df, headers="keys", tablefmt="grid", showindex=False))
             else:


### PR DESCRIPTION
## Summary
- add `--console-out` argument to backtest
- allow `30mMO1-3.py` to forward new option to backtest
- update documentation for new argument

## Testing
- `python -m py_compile backtest.py 30mMO1-3.py`

------
https://chatgpt.com/codex/tasks/task_e_686b0120e0ec8326a1aadf20beb57cb5