### PR TITLE
Round ticker data before saving

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -11,6 +11,8 @@ import time
 import pandas as pd
 import matplotlib.pyplot as plt
 
+from stock_functions import round_numeric_cols
+
 from stock_functions import choose_yfinance_interval, period_to_start_end
 from open_range import OpenRangeAnalyzer
 
@@ -351,6 +353,7 @@ def main() -> None:
                 tickers_df[col] = tickers_df[col].map(lambda x: f"{x:.2f}")
 
 
+        tickers_df = round_numeric_cols(tickers_df)
         tickers_df.to_csv(tickers_path, index=False)
 
         ticker_root = Path("tickers")
@@ -371,6 +374,7 @@ def main() -> None:
                 combined = pd.concat([existing, pd.DataFrame([row])], ignore_index=True)
             else:
                 combined = pd.DataFrame([row])
+            combined = round_numeric_cols(combined)
             combined.to_csv(dest_file, index=False)
         if args.tickers or "tickers" in args.console_out.split():
             if tabulate:

--- a/dumb.py
+++ b/dumb.py
@@ -1,12 +1,15 @@
 import yfinance as yf
 import pandas as pd
 
+from stock_functions import round_numeric_cols
+
 # Fetch data for a specific stock symbol
 symbol = 'AAPL'
 stock = yf.Ticker(symbol)
 
 # Convert the info dictionary to a DataFrame
 info_df = pd.DataFrame.from_dict(stock.info, orient='index', columns=['Value'])
+info_df = round_numeric_cols(info_df)
 
 # Print the DataFrame
 print(info_df)

--- a/fetch_daily_5m_bars.py
+++ b/fetch_daily_5m_bars.py
@@ -5,6 +5,8 @@ import logging
 import datetime
 import sys
 
+from stock_functions import round_numeric_cols
+
 # Set up logging
 logging.basicConfig(filename='stock_info.log', level=logging.ERROR, format='%(asctime)s:%(levelname)s:%(message)s')
 
@@ -24,6 +26,7 @@ def fetch_5min_data(ticker, date_str):
         if not os.path.exists(filename):
             stock = yf.Ticker(ticker)
             data = stock.history(interval='5m', start='2023-01-01', end='2023-12-31')  # Adjust the start and end dates as needed
+            data = round_numeric_cols(data)
             data.to_csv(filename)
             print(f"Fetched and saved 5-minute interval data for {ticker}")
         else:

--- a/fetch_us_stocks.py
+++ b/fetch_us_stocks.py
@@ -5,6 +5,8 @@ import pandas as pd
 import csv
 from pathlib import Path
 
+from stock_functions import round_numeric_cols
+
 # Read the Finnhub API key from API_KEY.txt located in the project root.
 # The file should contain only the API key string and must not be tracked by
 # version control.
@@ -25,6 +27,7 @@ def fetch_us_stocks():
 
     # Convert the list of dictionaries to a DataFrame
     df = pd.DataFrame(us_stocks)
+    df = round_numeric_cols(df)
 
     # Write the DataFrame to a CSV file
     output_file = 'us_stocks.csv'

--- a/stock_functions.py
+++ b/stock_functions.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+import pandas as pd
 
 
 def period_to_start_end(period: str, end: datetime | None = None) -> tuple[datetime, datetime]:
@@ -103,3 +104,11 @@ def choose_yfinance_interval(start=None, end=None, period=None):
             return interval
 
     return "1mo"  # fallback for extremely long durations
+
+
+def round_numeric_cols(df: pd.DataFrame, decimals: int = 2) -> pd.DataFrame:
+    """Return ``df`` with all numeric columns rounded."""
+    numeric_cols = df.select_dtypes(include="number").columns
+    if len(numeric_cols) > 0:
+        df[numeric_cols] = df[numeric_cols].round(decimals)
+    return df

--- a/stock_info_to_csv.py
+++ b/stock_info_to_csv.py
@@ -1,6 +1,8 @@
 import os
 import pandas as pd
 
+from stock_functions import round_numeric_cols
+
 def combine_info_to_csv(input_dir, output_file):
     # Initialize an empty list to store data from all .info files
     data = []
@@ -34,6 +36,7 @@ def combine_info_to_csv(input_dir, output_file):
 
     # Convert the list of dictionaries to a DataFrame
     df = pd.DataFrame(data)
+    df = round_numeric_cols(df)
 
     # Save the DataFrame to a CSV file
     df.to_csv(output_file, index=False)


### PR DESCRIPTION
## Summary
- add helper `round_numeric_cols`
- round ticker data when saving CSVs in multiple scripts
- keep dumb example consistent

## Testing
- `python -m py_compile $(git ls-files "*.py")`

------
https://chatgpt.com/codex/tasks/task_e_68797073ab3083268598a557ca338d93