### PR TITLE
Add date range info to ticker summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ In addition to the timestamped summary, each ticker's row is appended to
 symbol. These files are created automatically and accumulate the history
 of summary results for that ticker. A new row is skipped when the same
 `analysis_time` already exists in the file.
+Each row also records `start_date`, `end_date`, and `range` so you can
+see the analysis period and opening range used.
 Pass `--console-out trades` to print each trade in the terminal. Use `--tickers` or
 `--console-out tickers` to display the per-ticker summary in an ASCII table after the trades.
 The summary table is ordered by `total_profit` descending and entries

--- a/backtest.py
+++ b/backtest.py
@@ -218,6 +218,9 @@ def main() -> None:
                 "total_profit": results.total_profit,
                 "total_top_profit": results.total_top_profit,
                 "avg_trade_time": avg_minutes,
+                "start_date": start.strftime("%Y-%m-%d"),
+                "end_date": end.strftime("%Y-%m-%d"),
+                "range": args.range,
                 "analysis_time": timestamp,
             }
         )


### PR DESCRIPTION
## Summary
- include start and end dates plus range minutes in per-ticker rows
- mention new fields in README

## Testing
- `python backtest.py --help`
- `python -m py_compile backtest.py`

------
https://chatgpt.com/codex/tasks/task_e_68797754831c8326969781033c8b97dc