### PR TITLE
Filter trades by explicit parameters only

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ Each trade also reports `top_profit`, the percent gain from entry to the highest
 In addition to the timestamped summary, each ticker's row is appended to
 `tickers/<T>/<TICKER>.csv` where `<T>` is the first letter of the ticker
 symbol. These files are created automatically and accumulate the history
-of summary results for that ticker. A new row is skipped when the same
-`analysis_time` already exists in the file.
+of summary results for that ticker.
 Each row also records `start_date`, `end_date`, and `range` so you can
 see the analysis period and opening range used.
 Pass `--console-out trades` to print each trade in the terminal. Use `--tickers` or


### PR DESCRIPTION
## Summary
- drop `analysis_time` column handling
- return empty dataframe when `start_date`/`end_date` or range columns are absent
- update README accordingly

## Testing
- `python -m py_compile eldoradotoptrades.py`

------
https://chatgpt.com/codex/tasks/task_e_68798552b4c48326842c2c084d220c23