### PR TITLE
Share portfolio expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The opening range (the first hour high/low difference) is reported as
 
 ## Portfolios
 
-`backtest.py` supports saved portfolios. Prefix a portfolio name
+`backtest.py` and `neverland.py` support saved portfolios. Prefix a portfolio name
 with `+` to load tickers from a file in the `portfolios` directory. For
 example, running:
 

--- a/backtest.py
+++ b/backtest.py
@@ -15,29 +15,8 @@ from stock_functions import round_numeric_cols
 
 from stock_functions import choose_yfinance_interval, period_to_start_end
 from open_range import OpenRangeAnalyzer
+from portfolio_utils import expand_ticker_args
 
-
-def expand_ticker_args(ticker_args: list[str]) -> list[str]:
-    """Expand any portfolio references in ``ticker_args``.
-
-    Tickers beginning with ``+`` are treated as portfolio names. The
-    corresponding file in ``./portfolios`` is read and the contained
-    tickers are added to the list.
-    """
-    expanded: list[str] = []
-    for token in ticker_args:
-        if token.startswith("+"):
-            name = token[1:]
-            path = Path("portfolios") / f"{name}"
-            if path.exists():
-                expanded.extend(path.read_text().split())
-            else:
-                print(f"Portfolio file not found: {path}")
-        else:
-            expanded.append(token)
-
-    # Remove duplicates while preserving order
-    return list(dict.fromkeys(expanded))
 
 
 def main() -> None:

--- a/neverland.py
+++ b/neverland.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import pandas as pd
 
 from fetch_stock import fetch_stock
+from portfolio_utils import expand_ticker_args
 
 
 def fetch_intraday(ticker: str, start: pd.Timestamp, end: pd.Timestamp, interval: str = "5m") -> pd.DataFrame:
@@ -101,7 +102,9 @@ def main() -> None:
     start = pd.to_datetime(args.start)
     end = pd.to_datetime(args.end) if args.end else start
 
-    for ticker in args.tickers:
+    tickers = expand_ticker_args(args.tickers)
+
+    for ticker in tickers:
         hi, lo, avg, count = analyze_ticker(ticker, start, end, args.range)
         if count == 0:
             print(f"{ticker}: no data in range")

--- a/portfolio_utils.py
+++ b/portfolio_utils.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from typing import Iterable
+
+
+def expand_ticker_args(ticker_args: Iterable[str]) -> list[str]:
+    """Expand portfolio names prefixed with ``+`` to tickers.
+
+    Tokens beginning with ``+`` are treated as filenames in the
+    ``portfolios`` directory. The tickers inside are added to the
+    returned list. Duplicate tickers are removed while preserving order.
+    """
+    expanded: list[str] = []
+    for token in ticker_args:
+        if token.startswith("+"):
+            name = token[1:]
+            path = Path("portfolios") / name
+            if path.exists():
+                expanded.extend(path.read_text().split())
+            else:
+                print(f"Portfolio file not found: {path}")
+        else:
+            expanded.append(token)
+    # Remove duplicates while preserving order
+    return list(dict.fromkeys(expanded))


### PR DESCRIPTION
## Summary
- factor portfolio ticker expansion into `portfolio_utils`
- use shared function in `neverland.py` and `backtest.py`
- note portfolio support for `neverland.py` in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6881635ad988832692f18321f0f6f9b7