### PR TITLE
Add value_trades console output

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ In addition to the timestamped summary, all ticker rows are appended to
 accumulates the history of summary results for each analysis period and
 filter. Each row also records `start_date`, `end_date`, and `range` so
 you can see the analysis period and opening range used.
-Pass `--console-out trades` to print each trade in the terminal. Use `--tickers` or
+Pass `--console-out trades` to print each trade in the terminal. Use `--console-out value_trades` to
+show trade entry and exit prices along with gains. Use `--tickers` or
 `--console-out tickers` to display the per-ticker summary in an ASCII table after the trades.
 The summary table is ordered by `total_profit` descending and entries
 with profits less than the value passed to `--min-profit` are omitted.

--- a/open_range.py
+++ b/open_range.py
@@ -232,6 +232,7 @@ def analyze_open_range(
             )
             profit = ((sell - buy) / buy) * 100
             top_profit_pct = ((top_price - buy) / buy) * 100
+            gain_loss = sell - buy
             minutes = (
                 (sell_time - after_or_time).total_seconds() / 60
                 if pd.notna(sell_time)
@@ -251,9 +252,11 @@ def analyze_open_range(
                     "or_low": float(or_low),
                     "or_high": float(or_high),
                     "buy_price": float(buy),
+                    "sell_price": float(sell),
                     "stop_price": float(stop_price),
                     "profit_price": float(target_price),
                     "profit": float(profit),
+                    "gain_loss": float(gain_loss),
                     "top_profit": float(top_profit_pct),
                     "result": outcome,
                     "buy_time": after_or_time,


### PR DESCRIPTION
## Summary
- add `value_trades` option to the console output
- include sell price and gain/loss info in trade details
- document the new option in README

## Testing
- `python -m py_compile backtest.py open_range.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688172c280808326aa1538f5b7e6a559