### PR TITLE
Implement portfolio exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ AMZN MSFT AAPL NVDA META GOOG TSLA MU AVGO
 Duplicate tickers are ignored, so the portfolio and command-line
 arguments can safely include overlapping symbols.
 
+Prefixing a portfolio name with ``-`` will remove any tickers listed in
+that file from the final set.  Additions are processed before
+exclusions, so ``python backtest.py +M9 -Tech`` loads the ``M9``
+portfolio and then excludes the tickers found in ``portfolios/Tech``.
+
 If you omit both `--period` and `--start`, `backtest.py` will
 analyze a single day automatically. When run before 9:30 AM US/Eastern it
 uses the previous trading day (adjusting for weekends); otherwise it uses

--- a/current_price.py
+++ b/current_price.py
@@ -4,33 +4,11 @@ try:
     from tabulate import tabulate
 except Exception:
     tabulate = None
-from pathlib import Path
-from typing import Iterable
+from portfolio_utils import expand_ticker_args
 
 import pandas as pd
 
 from fetch_stock import fetch_stock
-
-
-def expand_ticker_args(ticker_args: Iterable[str]) -> list[str]:
-    """Expand any portfolio references in ``ticker_args``.
-
-    Tokens beginning with ``+`` are treated as portfolio filenames under
-    ``./portfolios``. The tickers listed inside are added to the result.
-    """
-    expanded: list[str] = []
-    for token in ticker_args:
-        if token.startswith("+"):
-            name = token[1:]
-            path = Path("portfolios") / name
-            if path.exists():
-                expanded.extend(path.read_text().split())
-            else:
-                print(f"Portfolio file not found: {path}")
-        else:
-            expanded.append(token)
-    return expanded
-
 
 def fetch_last_open_close(ticker: str) -> tuple[float, float] | None:
     """Return the last day's open and close for ``ticker``."""

--- a/portfolio_utils.py
+++ b/portfolio_utils.py
@@ -3,13 +3,18 @@ from typing import Iterable
 
 
 def expand_ticker_args(ticker_args: Iterable[str]) -> list[str]:
-    """Expand portfolio names prefixed with ``+`` to tickers.
+    """Expand portfolio names prefixed with ``+`` or ``-`` to tickers.
 
     Tokens beginning with ``+`` are treated as filenames in the
-    ``portfolios`` directory. The tickers inside are added to the
-    returned list. Duplicate tickers are removed while preserving order.
+    ``portfolios`` directory.  Their tickers are added to the returned
+    list.  Tokens beginning with ``-`` also reference files under
+    ``portfolios`` but the tickers they contain are removed from the
+    final result.  Duplicate tickers are removed while preserving order
+    after all additions and exclusions are processed.
     """
+
     expanded: list[str] = []
+    exclude_files: list[str] = []
     for token in ticker_args:
         if token.startswith("+"):
             name = token[1:]
@@ -18,7 +23,21 @@ def expand_ticker_args(ticker_args: Iterable[str]) -> list[str]:
                 expanded.extend(path.read_text().split())
             else:
                 print(f"Portfolio file not found: {path}")
+        elif token.startswith("-"):
+            exclude_files.append(token[1:])
         else:
             expanded.append(token)
+
     # Remove duplicates while preserving order
-    return list(dict.fromkeys(expanded))
+    result = list(dict.fromkeys(expanded))
+
+    # Exclude tickers from ``-`` portfolios
+    for name in exclude_files:
+        path = Path("portfolios") / name
+        if path.exists():
+            exclusions = set(path.read_text().split())
+            result = [t for t in result if t not in exclusions]
+        else:
+            print(f"Portfolio file not found: {path}")
+
+    return result

--- a/position_size.py
+++ b/position_size.py
@@ -1,28 +1,9 @@
 import argparse
 import math
-from pathlib import Path
 import pandas as pd
 
 from fetch_stock import fetch_stock
-
-
-def expand_ticker_args(ticker_args: list[str]) -> list[str]:
-    """Expand portfolio names prefixed with ``+`` to tickers.
-
-    Tickers are read from files in the ``portfolios`` directory.
-    """
-    expanded: list[str] = []
-    for token in ticker_args:
-        if token.startswith("+"):
-            name = token[1:]
-            path = Path("portfolios") / name
-            if path.exists():
-                expanded.extend(path.read_text().split())
-            else:
-                print(f"Portfolio file not found: {path}")
-        else:
-            expanded.append(token)
-    return expanded
+from portfolio_utils import expand_ticker_args
 
 
 def fetch_latest_price(ticker: str) -> float | None:


### PR DESCRIPTION
## Summary
- support subtracting tickers via `-<portfolio>` when expanding portfolios
- use the shared helper everywhere
- document exclusion support

## Testing
- `python -m py_compile portfolio_utils.py current_price.py position_size.py`

------
https://chatgpt.com/codex/tasks/task_e_6882ae8e481c8326b59009615fae2e35