### PR TITLE
Skip tickers with no trades in Taygetus console output

### DIFF
--- a/taygetusBacktest.py
+++ b/taygetusBacktest.py
@@ -109,15 +109,16 @@ def main() -> None:
         win_pct = wins / count * 100 if count else 0.0
         loss_pct = (count - wins) / count * 100 if count else 0.0
         if args.console_out == 'tickers':
-            rows.append(
-                {
-                    'ticker': ticker,
-                    'trades': count,
-                    'win_pct': win_pct,
-                    'loss_pct': loss_pct,
-                    'avg_gain_loss': avg,
-                }
-            )
+            if count:  # filter out tickers with zero trades
+                rows.append(
+                    {
+                        'ticker': ticker,
+                        'trades': count,
+                        'win_pct': win_pct,
+                        'loss_pct': loss_pct,
+                        'avg_gain_loss': avg,
+                    }
+                )
         elif args.console_out == 'trades':
             for trade in trades:
                 trade_rows.append({'ticker': ticker, **trade})


### PR DESCRIPTION
## Summary
- Avoid listing tickers without trades when using `--console-out tickers` in the Taygetus backtest.

## Testing
- `python -m py_compile taygetusBacktest.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68915b9f8b2c8326a1bf6f87f71659dc