### PR TITLE
Add console buy output for current day

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ filter. Each row also records `start_date`, `end_date`, and `range` so
 you can see the analysis period and opening range used.
 Pass `--console-out trades` to print each trade in the terminal. Use `--tickers` or
 `--console-out tickers` to display the per-ticker summary in an ASCII table after the trades.
+Use `--console-out buys` with `--end` set to today's date to print open entries identified for the current day.
 The summary table is ordered by `total_profit` descending and entries
 with profits less than the value passed to `--min-profit` are omitted.
 Pass `--plot daily` to generate a single plot summarizing daily activity. The


### PR DESCRIPTION
## Summary
- allow `--console-out buys` to display today's entries without an exit when `--end` is today
- document `--console-out buys`

## Testing
- `python -m py_compile eldoradoBacktest.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892594217dc8326943c2f3126073177