### PR TITLE
Handle multi-index columns when fetching current price

### DIFF
--- a/taygetusBacktest.py
+++ b/taygetusBacktest.py
@@ -42,7 +42,9 @@ def fetch_current_price(ticker: str) -> float | None:
     )
     if data.empty:
         return None
-    return float(data["Close"].iloc[-1])
+    if isinstance(data.columns, pd.MultiIndex):
+        data.columns = data.columns.get_level_values(0)
+    return data["Close"].iloc[-1].item()
 
 
 def backtest_pattern(


### PR DESCRIPTION
## Summary
- flatten yfinance results in `fetch_current_price` to avoid single-element Series
- return the last closing value via `.item()` for compatibility with upcoming pandas changes

## Testing
- `python -m py_compile taygetusBacktest.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689260f07e0c83269c365c6419e109f4