### PR TITLE
Add uppercase ticker list for today's buys

### DIFF
--- a/taygetusBacktest.py
+++ b/taygetusBacktest.py
@@ -318,6 +318,8 @@ def main() -> None:
         print("Today's buys:")
         for row in today_buys:
             print(f"{row['ticker']}: {row['price']:.2f}")
+        tickers_line = " ".join(t["ticker"].upper() for t in today_buys)
+        print(tickers_line)
 
     if total_trades:
         overall = total_return / total_trades


### PR DESCRIPTION
## Summary
- Print space separated uppercase tickers for today's buys in Taygetus backtest.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892889126848326af5f607ed3da6d62