### PR TITLE
Add opt-in indicator filtering to backtests

### DIFF
--- a/eldoradoBacktest.py
+++ b/eldoradoBacktest.py
@@ -124,8 +124,26 @@ def main() -> None:
     )
     parser.add_argument(
         "--indicators",
-        action="store_true",
-        help="Enable indicator-based filters",  # default was on
+        nargs="+",
+        choices=[
+            "price",
+            "avg_vol",
+            "dollar_vol",
+            "atr_pct",
+            "above_sma",
+            "trend_slope",
+            "nr7",
+            "inside_2",
+            "body_pct",
+            "upper_wick",
+            "lower_wick",
+            "pullback_pct",
+            "gap",
+        ],
+        help=(
+            "Indicator filters to enable (default none). "
+            "Example: --indicators price atr_pct gap"  # previously all enabled by default
+        ),
     )
     # === Filtering flags ===
     parser.add_argument("--min-price", type=float, default=5.0)
@@ -136,8 +154,6 @@ def main() -> None:
     parser.add_argument("--max-atr-pct", type=float, default=8.0)
     parser.add_argument("--above-sma", type=int, choices=[20, 50, 200], default=20)
     parser.add_argument("--trend-slope", type=float, default=0.0)
-    parser.add_argument("--nr7", action="store_true")
-    parser.add_argument("--inside-2", dest="inside_2", action="store_true")
     parser.add_argument("--min-gap-pct", type=float, default=0.4)
     parser.add_argument("--body-pct-min", dest="body_pct_min", type=float, default=60.0)
     parser.add_argument("--upper-wick-max", dest="upper_wick_max", type=float, default=30.0)
@@ -236,7 +252,7 @@ def main() -> None:
             exit_day = (pd.Timestamp(trade_date) + BDay(1)).date()
             idx = daily_df.index[daily_df["Date"].dt.date == exit_day]
             if len(idx) and (
-                not args.indicators or passes_filters(daily_df, int(idx[0]), args)
+                not args.indicators or passes_filters(daily_df, int(idx[0]), args, args.indicators)
             ):
                 filtered_details.append(item)
         results.trade_details = filtered_details

--- a/neverland.py
+++ b/neverland.py
@@ -145,7 +145,7 @@ def analyze_ticker(
         sell_date = pd.to_datetime(row["sell_time"]).date()
         idx = daily_df.index[daily_df["Date"].dt.date == sell_date]
         if len(idx) and (
-            not args.indicators or passes_filters(daily_df, int(idx[0]), args)
+            not args.indicators or passes_filters(daily_df, int(idx[0]), args, args.indicators)
         ):
             mask.append(True)
         else:
@@ -202,8 +202,26 @@ def main() -> None:
     )
     parser.add_argument(
         "--indicators",
-        action="store_true",
-        help="Enable indicator-based filters",  # default was on
+        nargs="+",
+        choices=[
+            "price",
+            "avg_vol",
+            "dollar_vol",
+            "atr_pct",
+            "above_sma",
+            "trend_slope",
+            "nr7",
+            "inside_2",
+            "body_pct",
+            "upper_wick",
+            "lower_wick",
+            "pullback_pct",
+            "gap",
+        ],
+        help=(
+            "Indicator filters to enable (default none). "
+            "Example: --indicators price atr_pct gap"  # previously all enabled by default
+        ),
     )
     # === Filtering flags ===
     parser.add_argument("--min-price", type=float, default=5.0)
@@ -214,8 +232,6 @@ def main() -> None:
     parser.add_argument("--max-atr-pct", type=float, default=8.0)
     parser.add_argument("--above-sma", type=int, choices=[20, 50, 200], default=20)
     parser.add_argument("--trend-slope", type=float, default=0.0)
-    parser.add_argument("--nr7", action="store_true")
-    parser.add_argument("--inside-2", dest="inside_2", action="store_true")
     parser.add_argument("--min-gap-pct", type=float, default=0.4)
     parser.add_argument("--body-pct-min", dest="body_pct_min", type=float, default=60.0)
     parser.add_argument("--upper-wick-max", dest="upper_wick_max", type=float, default=30.0)

--- a/taygetusBacktest.py
+++ b/taygetusBacktest.py
@@ -117,7 +117,7 @@ def backtest_pattern(
             pass
 
         if entry_price is not None and (
-            not args.indicators or passes_filters(df, i, args)
+            not args.indicators or passes_filters(df, i, args, args.indicators)
         ):
             exit_open = days["day1"]["Open"]
             exit_close = days["day1"]["Close"]
@@ -168,8 +168,26 @@ def main() -> None:
     )
     parser.add_argument(
         '--indicators',
-        action='store_true',
-        help='Enable indicator-based filters',  # default was on
+        nargs='+',
+        choices=[
+            'price',
+            'avg_vol',
+            'dollar_vol',
+            'atr_pct',
+            'above_sma',
+            'trend_slope',
+            'nr7',
+            'inside_2',
+            'body_pct',
+            'upper_wick',
+            'lower_wick',
+            'pullback_pct',
+            'gap',
+        ],
+        help=(
+            'Indicator filters to enable (default none). '
+            'Example: --indicators price atr_pct gap'  # previously all enabled by default
+        ),
     )
     # === Filtering flags ===
     parser.add_argument("--min-price", type=float, default=5.0)
@@ -180,8 +198,6 @@ def main() -> None:
     parser.add_argument("--max-atr-pct", type=float, default=8.0)
     parser.add_argument("--above-sma", type=int, choices=[20, 50, 200], default=20)
     parser.add_argument("--trend-slope", type=float, default=0.0)  # SMA20 - SMA20_5dago > this
-    parser.add_argument("--nr7", action="store_true")
-    parser.add_argument("--inside-2", dest="inside_2", action="store_true")
     parser.add_argument("--min-gap-pct", type=float, default=0.4)
     parser.add_argument("--body-pct-min", dest="body_pct_min", type=float, default=60.0)
     parser.add_argument("--upper-wick-max", dest="upper_wick_max", type=float, default=30.0)
@@ -323,7 +339,7 @@ def main() -> None:
             if match:
                 idx = df.index[df["Date"] == original_end]
                 if len(idx) and (
-                    not args.indicators or passes_filters(df, int(idx[0]), args)
+                    not args.indicators or passes_filters(df, int(idx[0]), args, args.indicators)
                 ):
                     price = fetch_current_price(ticker)
                     if price is not None:


### PR DESCRIPTION
## Summary
- add `--indicators` flag to eldorado, taygetus, and neverland backtests to disable indicator filters unless requested
- apply indicators and filtering only when the new flag is supplied

## Testing
- `python -m py_compile eldoradoBacktest.py taygetusBacktest.py neverland.py`


------
https://chatgpt.com/codex/tasks/task_e_6897a237bc708326afb248563690d35b