### PR TITLE
Avoid pandas future warning

### DIFF
--- a/backtest_filters.py
+++ b/backtest_filters.py
@@ -127,7 +127,7 @@ def merge_indicator_data(df: pd.DataFrame, ticker: str) -> tuple[pd.DataFrame, b
     merged = df.merge(ind, on="Date", how="left")
     cols = [c for c in ind.columns if c != "Date"]
     if cols:
-        merged[cols] = merged[cols].ffill()
+        merged[cols] = merged[cols].ffill().infer_objects(copy=False)
     return merged, True
 
 


### PR DESCRIPTION
## Summary
- call `infer_objects(copy=False)` after `ffill` to preserve dtypes and avoid future pandas warnings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a29a50091c8326bf60b368f798fbcb