### PR TITLE
Add below_sma indicator filter

### DIFF
--- a/backtest_filters.py
+++ b/backtest_filters.py
@@ -176,6 +176,10 @@ def passes_filters(
         sma_col = f"SMA{args.above_sma}"
         if pd.isna(d2.get(sma_col)) or not (d2["Close"] > d2[sma_col]):
             return False
+    if "below_sma" in enabled:
+        sma_col = f"SMA{args.below_sma}"
+        if pd.isna(d2.get(sma_col)) or not (d2["Close"] < d2[sma_col]):
+            return False
     if "trend_slope" in enabled:
         if pd.isna(d2.get("SMA20")) or pd.isna(d2.get("SMA20_5dago")):
             return False

--- a/eldoradoBacktest.py
+++ b/eldoradoBacktest.py
@@ -131,6 +131,7 @@ def main() -> None:
             "dollar_vol",
             "atr_pct",
             "above_sma",
+            "below_sma",
             "trend_slope",
             "nr7",
             "inside_2",
@@ -153,6 +154,7 @@ def main() -> None:
     parser.add_argument("--min-atr-pct", type=float, default=1.0)
     parser.add_argument("--max-atr-pct", type=float, default=8.0)
     parser.add_argument("--above-sma", type=int, choices=[20, 50, 200], default=20)
+    parser.add_argument("--below-sma", type=int, choices=[20, 50, 200], default=20)
     parser.add_argument("--trend-slope", type=float, default=0.0)
     parser.add_argument("--min-gap-pct", type=float, default=0.4)
     parser.add_argument("--body-pct-min", dest="body_pct_min", type=float, default=60.0)

--- a/indicators.py
+++ b/indicators.py
@@ -91,6 +91,7 @@ def main() -> None:
         "nr7",
         "inside_2",
         "above_sma",
+        "below_sma",
         "trend_slope",
         "pullback_pct",
         "gap",
@@ -107,6 +108,8 @@ def main() -> None:
     if "inside_2" in enabled:
         req = max(req, 3)
     if "above_sma" in enabled:
+        req = max(req, 20)
+    if "below_sma" in enabled:
         req = max(req, 20)
     if "trend_slope" in enabled:
         req = max(req, 25)

--- a/neverland.py
+++ b/neverland.py
@@ -212,6 +212,7 @@ def main() -> None:
             "dollar_vol",
             "atr_pct",
             "above_sma",
+            "below_sma",
             "trend_slope",
             "nr7",
             "inside_2",
@@ -234,6 +235,7 @@ def main() -> None:
     parser.add_argument("--min-atr-pct", type=float, default=1.0)
     parser.add_argument("--max-atr-pct", type=float, default=8.0)
     parser.add_argument("--above-sma", type=int, choices=[20, 50, 200], default=20)
+    parser.add_argument("--below-sma", type=int, choices=[20, 50, 200], default=20)
     parser.add_argument("--trend-slope", type=float, default=0.0)
     parser.add_argument("--min-gap-pct", type=float, default=0.4)
     parser.add_argument("--body-pct-min", dest="body_pct_min", type=float, default=60.0)

--- a/taygetusBacktest.py
+++ b/taygetusBacktest.py
@@ -211,6 +211,7 @@ def main() -> None:
             'dollar_vol',
             'atr_pct',
             'above_sma',
+            'below_sma',
             'trend_slope',
             'nr7',
             'inside_2',
@@ -233,6 +234,7 @@ def main() -> None:
     parser.add_argument("--min-atr-pct", type=float, default=1.0)
     parser.add_argument("--max-atr-pct", type=float, default=8.0)
     parser.add_argument("--above-sma", type=int, choices=[20, 50, 200], default=20)
+    parser.add_argument("--below-sma", type=int, choices=[20, 50, 200], default=20)
     parser.add_argument("--trend-slope", type=float, default=0.0)  # SMA20 - SMA20_5dago > this
     parser.add_argument("--min-gap-pct", type=float, default=0.4)
     parser.add_argument("--body-pct-min", dest="body_pct_min", type=float, default=60.0)


### PR DESCRIPTION
## Summary
- add `below_sma` option to indicator dataset generator and backtest scripts
- support `below_sma` filter in passes_filters

## Testing
- `python -m py_compile backtest_filters.py indicators.py eldoradoBacktest.py taygetusBacktest.py neverland.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a375a395388326b7ffcf732f788adb