### PR TITLE
Add MPC market-to-previous-close filter to backtest

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Use `--filter` to control the relationship between the opening range
 close (Mark) and the day's open that must be satisfied before entering a
 trade. `--filter-offset` multiplies the open price used in that check.
 Available filters include `MO` (Mark > Open), `OM` (Open > Mark), `ORM`
-(Buy Price * 1.002 > Open Range High), `GU` (Open above previous close)
-and `GD` (Open below previous close).
+(Buy Price * 1.002 > Open Range High), `GU` (Open above previous close),
+`GD` (Open below previous close) and `MPC` (Mark > Previous Close).
 
 When the analysis completes, all trades are written to `./output/<timestamp>_trades.csv` and a per-ticker summary is saved to `./output/<timestamp>_tickers.csv`. The summary lists the total number of trades, the percentage of profitable trades, and the cumulative profit for each ticker. It also includes `total_top_profit`, the sum of potential profits based on each trade's peak price.
 The trades file includes a `profit_or_loss` column after `sell_time` showing whether each trade hit the profit target, stop loss, or closed at the end of the day.

--- a/eldoradoBacktest.py
+++ b/eldoradoBacktest.py
@@ -84,7 +84,7 @@ def main() -> None:
             "Space-separated trade filters. Prefix with ! to invert. "
             "Available filters: MO (Mark > Open), OM (Open > Mark), ORM (Buy "
             "Price * 1.002 > Open Range High), GU (Open > Prev Close), "
-            "GD (Open < Prev Close)"
+            "GD (Open < Prev Close), MPC (Mark > Prev Close)"
         ),
     )
     parser.add_argument(

--- a/eldoradoPredictions.py
+++ b/eldoradoPredictions.py
@@ -238,7 +238,7 @@ def main() -> None:
         default="MO",
         help=(
             "Space-separated trade filters. Prefix with ! to invert. "
-            "Available filters: MO, OM, ORM"
+            "Available filters: MO, OM, ORM, GU, GD, MPC"
         ),
     )
     parser.add_argument(

--- a/open_range.py
+++ b/open_range.py
@@ -212,6 +212,11 @@ def analyze_open_range(
                 check = open_price > after_or_price * filter_offset
             elif name.upper() == "ORM":
                 check = after_or_price  > or_high * 0.9965
+            elif name.upper() == "MPC":
+                check = (
+                    prev_close is not None
+                    and after_or_price > prev_close * filter_offset
+                )
             elif name.upper() == "GU":
                 check = gap_up
             elif name.upper() == "GD":


### PR DESCRIPTION
## Summary
- add MPC filter comparing post-range price to previous close in OpenRangeAnalyzer
- document MPC filter in README, Eldorado backtest and predictions scripts

## Testing
- `python -m py_compile open_range.py eldoradoBacktest.py eldoradoPredictions.py`
- `pip install matplotlib`
- `python eldoradoBacktest.py AAPL --period 5d --filter MPC --max-trades 1`


------
https://chatgpt.com/codex/tasks/task_e_68af1c5a6e8c8326b9ca8a8ad469b59d