### PR TITLE
Fix missing stocks import in Streamlit Taygetus page

### DIFF
--- a/app/pages/3_Taygetus.py
+++ b/app/pages/3_Taygetus.py
@@ -1,4 +1,9 @@
 import streamlit as st
+from pathlib import Path
+import sys
+
+# Ensure project root is on sys.path for module imports
+sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from stocks.backtests.taygetus import backtest_pattern
 from stocks.data.fetch import fetch_ticker


### PR DESCRIPTION
## Summary
- ensure project root is on `sys.path` in Taygetus page so `stocks` modules import correctly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b313fc35ac8326b7bac35dac670b9c