### PR TITLE
Ensure trade dataframes always include expected columns

### DIFF
--- a/tests/test_taygetus.py
+++ b/tests/test_taygetus.py
@@ -45,3 +45,10 @@ def test_3eu_pattern():
     trades = backtest_pattern(df, "3EU")
     assert trades.iloc[0].entry_day == 6
     assert trades.iloc[0].exit_day == 7
+
+
+def test_no_trades_has_expected_columns():
+    df = pd.DataFrame(columns=["Date", "Open", "High", "Low", "Close"])
+    trades = backtest_pattern(df, "3OUCU")
+    assert trades.empty
+    assert "entry_day" in trades.columns


### PR DESCRIPTION
## Summary
- Guarantee Taygetus backtests return dataframes with consistent columns even when no trades are found
- Cover empty-trade scenario with regression test

## Testing
- `flake8 stocks cli tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b344ea29f08326a091c9915ffaa72c