### PR TITLE
Handle invalid cache in fetch_ticker

### DIFF
--- a/stocks/data/fetch.py
+++ b/stocks/data/fetch.py
@@ -25,7 +25,10 @@ def fetch_ticker(
     cache_key = f"{ticker}_{start}_{end}_{use_period}.csv".replace("None", "-")
     cache_path = CACHE_DIR / cache_key
     if cache_path.exists() and not force:
-        return pd.read_csv(cache_path, parse_dates=["Date"], index_col="Date")
+        try:
+            return pd.read_csv(cache_path, parse_dates=["Date"], index_col="Date")
+        except (ValueError, KeyError, pd.errors.EmptyDataError):
+            cache_path.unlink(missing_ok=True)
 
     kwargs = {"auto_adjust": True, "progress": False}
     if start or end:

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,0 +1,28 @@
+import pandas as pd
+
+from stocks.data import fetch
+
+
+def test_fetch_ticker_recovers_from_invalid_cache(tmp_path, monkeypatch):
+    monkeypatch.setattr(fetch, "CACHE_DIR", tmp_path)
+    cache_file = tmp_path / "FAKE_-_-_1mo.csv"
+    cache_file.write_text("Open,High,Low,Close\n1,2,3,4\n")
+
+    df_stub = pd.DataFrame({"Open": [1.0], "High": [2.0], "Low": [3.0], "Close": [4.0]}, index=pd.to_datetime(["2020-01-01"]))
+    df_stub.index.name = "Date"
+
+    calls = []
+
+    def fake_download(*args, **kwargs):
+        calls.append(1)
+        return df_stub
+
+    monkeypatch.setattr(fetch.yf, "download", fake_download)
+
+    result1 = fetch.fetch_ticker("FAKE", period="1mo")
+    assert result1.equals(df_stub)
+    assert len(calls) == 1
+
+    result2 = fetch.fetch_ticker("FAKE", period="1mo")
+    assert result2.equals(df_stub)
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary
- safeguard cached CSV loads by retrying downloads when cache files lack a Date column or are empty
- test that fetch_ticker recovers from an invalid cached CSV and caches fresh data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b34d0b83848326a63c058f80eaa875