### PR TITLE
Expand Taygetus portfolios

### DIFF
--- a/app/pages/3_Taygetus.py
+++ b/app/pages/3_Taygetus.py
@@ -16,7 +16,11 @@ from stocks.utils.plots import equity_curve, gain_loss_bar
 
 st.title("Taygetus Backtest")
 
-tickers_input = st.text_input("Tickers", "AAPL")
+tickers_input = st.text_input(
+    "Tickers",
+    "AAPL",
+    help="Prefix with +<portfolio> to load tickers from the portfolios folder.",
+)
 col1, col2, col3, col4 = st.columns(4)
 with col1:
     start = st.date_input(

--- a/portfolio_utils.py
+++ b/portfolio_utils.py
@@ -3,6 +3,10 @@ from typing import Iterable, Sequence
 import re
 
 
+# Absolute path to the repository's ``portfolios`` directory.
+PORTFOLIOS_DIR = Path(__file__).resolve().with_name("portfolios")
+
+
 def expand_ticker_args(ticker_args: Iterable[str]) -> list[str]:
     """Expand portfolio names prefixed with ``+`` or ``-`` to tickers.
 
@@ -19,7 +23,7 @@ def expand_ticker_args(ticker_args: Iterable[str]) -> list[str]:
     for token in ticker_args:
         if token.startswith("+"):
             name = token[1:]
-            path = Path("portfolios") / name
+            path = PORTFOLIOS_DIR / name
             if path.exists():
                 expanded.extend(path.read_text().split())
             else:
@@ -34,7 +38,7 @@ def expand_ticker_args(ticker_args: Iterable[str]) -> list[str]:
 
     # Exclude tickers from ``-`` portfolios
     for name in exclude_files:
-        path = Path("portfolios") / name
+        path = PORTFOLIOS_DIR / name
         if path.exists():
             exclusions = set(path.read_text().split())
             result = [t for t in result if t not in exclusions]

--- a/tests/test_portfolio_utils.py
+++ b/tests/test_portfolio_utils.py
@@ -1,0 +1,11 @@
+import portfolio_utils
+
+
+def test_expand_ticker_args_from_portfolio(tmp_path, monkeypatch):
+    portfolios_dir = tmp_path / "portfolios"
+    portfolios_dir.mkdir()
+    (portfolios_dir / "sample").write_text("AAPL MSFT")
+    monkeypatch.setattr(portfolio_utils, "PORTFOLIOS_DIR", portfolios_dir)
+
+    expanded = portfolio_utils.expand_ticker_args(["+sample"])
+    assert expanded == ["AAPL", "MSFT"]


### PR DESCRIPTION
## Summary
- allow Taygetus backtest to describe `+<portfolio>` usage
- resolve portfolio paths relative to project root
- test ticker expansion for portfolio prefixes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3573e2ab48326afa6281d47b76351