### PR TITLE
Add equity curve and chart to Taygetus summary

### DIFF
--- a/app/pages/3_Taygetus.py
+++ b/app/pages/3_Taygetus.py
@@ -62,6 +62,12 @@ if st.button("Run"):
         }
         st.subheader("Summary")
         st.write(summary_all)
+        st.subheader("Trades")
+        st.dataframe(combined)
+        st.subheader("Equity Curve")
+        st.altair_chart(equity_curve(combined), use_container_width=True)
+        st.subheader("Gain/Loss")
+        st.altair_chart(gain_loss_bar(combined), use_container_width=True)
 
     for ticker, trades in ticker_trades[: int(max_out)]:
         st.subheader(f"Trades - {ticker}")


### PR DESCRIPTION
## Summary
- show overall trades dataframe in Taygetus summary
- display equity curve and gain/loss charts for combined trades

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b385a8e85483269cb1ce33dc1e225a