### PR TITLE
Use dates on Taygetus equity curve

### DIFF
--- a/stocks/utils/plots.py
+++ b/stocks/utils/plots.py
@@ -10,8 +10,14 @@ def equity_curve(trades: pd.DataFrame) -> alt.Chart:
         return alt.Chart(pd.DataFrame({"x": [], "equity": []})).mark_line()
     df = trades.copy()
     df["equity"] = (1 + df["gain_loss_pct"] / 100).cumprod()
-    df["trade"] = range(len(df))
-    return alt.Chart(df).mark_line().encode(x="trade", y="equity")
+    if "exit_day" in df.columns:
+        df = df.sort_values("exit_day")
+        df["exit_day"] = pd.to_datetime(df["exit_day"])
+        x_enc = alt.X("exit_day:T", title="Date")
+    else:  # fallback to trade index if dates are unavailable
+        df["trade"] = range(len(df))
+        x_enc = "trade"
+    return alt.Chart(df).mark_line().encode(x=x_enc, y="equity")
 
 
 def gain_loss_bar(trades: pd.DataFrame) -> alt.Chart:


### PR DESCRIPTION
## Summary
- Show cumulative equity over time using trade exit dates on Taygetus plots

## Testing
- `make lint` *(fails: stocks/data/fetch.py:29:80: E501 line too long (82 > 79 characters))*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b48de2ba4c8326a231ab256ffdaa9b