### PR TITLE
Aggregate equity curve by day

### DIFF
--- a/stocks/utils/plots.py
+++ b/stocks/utils/plots.py
@@ -5,19 +5,39 @@ import pandas as pd
 
 
 def equity_curve(trades: pd.DataFrame) -> alt.Chart:
-    """Return an Altair line chart of cumulative equity."""
+    """Return an Altair line chart of cumulative equity.
+
+    When ``exit_day`` is present, gains are aggregated by day and the
+    resulting cumulative change is plotted by date.  Otherwise the
+    cumulative equity per trade index is shown.
+    """
+
     if trades.empty:
         return alt.Chart(pd.DataFrame({"x": [], "equity": []})).mark_line()
+
     df = trades.copy()
-    df["equity"] = (1 + df["gain_loss_pct"] / 100).cumprod()
+
     if "exit_day" in df.columns:
-        df = df.sort_values("exit_day")
         df["exit_day"] = pd.to_datetime(df["exit_day"])
-        x_enc = alt.X("exit_day:T", title="Date")
-    else:  # fallback to trade index if dates are unavailable
-        df["trade"] = range(len(df))
-        x_enc = "trade"
-    return alt.Chart(df).mark_line().encode(x=x_enc, y="equity")
+        df = df.sort_values("exit_day")
+
+        daily = df.groupby("exit_day")["gain_loss_pct"].sum()
+        daily = daily.reindex(
+            pd.date_range(daily.index.min(), daily.index.max()), fill_value=0
+        )
+
+        equity = (1 + daily / 100).cumprod()
+        plot_df = equity.reset_index()
+        plot_df.columns = ["exit_day", "equity"]
+        return (
+            alt.Chart(plot_df)
+            .mark_line()
+            .encode(x=alt.X("exit_day:T", title="Date"), y="equity")
+        )
+
+    df["equity"] = (1 + df["gain_loss_pct"] / 100).cumprod()
+    df["trade"] = range(len(df))
+    return alt.Chart(df).mark_line().encode(x="trade", y="equity")
 
 
 def gain_loss_bar(trades: pd.DataFrame) -> alt.Chart:

--- a/tests/test_equity_curve.py
+++ b/tests/test_equity_curve.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from stocks.utils.plots import equity_curve  # noqa: E402
+
+
+def test_equity_curve_cumulative_change_per_day():
+    trades = pd.DataFrame(
+        {
+            "exit_day": ["2024-01-01", "2024-01-01", "2024-01-03"],
+            "gain_loss_pct": [10, -5, 20],
+        }
+    )
+
+    chart = equity_curve(trades)
+    df = pd.DataFrame(chart.data)
+
+    expected_dates = pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03"])
+    assert list(df["exit_day"]) == list(expected_dates)
+
+    expected_equity = [1.05, 1.05, 1.26]
+    assert list(df["equity"].round(2)) == expected_equity


### PR DESCRIPTION
## Summary
- Update equity_curve to aggregate gains by exit day and plot cumulative equity per day
- Add regression test verifying daily equity curve behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b48fb74004832681cf115a974acb38