### PR TITLE
Remove decimal defaults from Taygetus indicators

### DIFF
--- a/app/pages/3_Taygetus.py
+++ b/app/pages/3_Taygetus.py
@@ -63,20 +63,23 @@ with st.expander("Indicator Filters"):
     with col_a:
         min_price = st.number_input(
             "Min Price",
-            value=float(DEFAULT_FILTER_ARGS["min_price"]),
+            value=int(DEFAULT_FILTER_ARGS["min_price"]),
+            step=1,
         )
         min_avg_vol = st.number_input(
             "Min Avg Vol",
-            value=float(DEFAULT_FILTER_ARGS["min_avg_vol"]),
+            value=int(DEFAULT_FILTER_ARGS["min_avg_vol"]),
+            step=1,
         )
         min_dollar_vol = st.number_input(
             "Min Dollar Vol",
-            value=float(DEFAULT_FILTER_ARGS["min_dollar_vol"]),
-            step=1.0,
+            value=int(DEFAULT_FILTER_ARGS["min_dollar_vol"]),
+            step=1,
         )
         min_atr_pct = st.number_input(
             "Min ATR %",
-            value=float(DEFAULT_FILTER_ARGS["min_atr_pct"]),
+            value=int(DEFAULT_FILTER_ARGS["min_atr_pct"]),
+            step=1,
         )
         above_sma = st.selectbox(
             "Above SMA",
@@ -85,28 +88,34 @@ with st.expander("Indicator Filters"):
         )
         trend_slope = st.number_input(
             "Trend Slope",
-            value=float(DEFAULT_FILTER_ARGS["trend_slope"]),
+            value=int(DEFAULT_FILTER_ARGS["trend_slope"]),
+            step=1,
         )
         body_pct_min = st.number_input(
             "Body % Min",
-            value=float(DEFAULT_FILTER_ARGS["body_pct_min"]),
+            value=int(DEFAULT_FILTER_ARGS["body_pct_min"]),
+            step=1,
         )
         upper_wick_max = st.number_input(
             "Upper Wick % Max",
-            value=float(DEFAULT_FILTER_ARGS["upper_wick_max"]),
+            value=int(DEFAULT_FILTER_ARGS["upper_wick_max"]),
+            step=1,
         )
         pullback_pct_max = st.number_input(
             "Pullback % Max",
-            value=float(DEFAULT_FILTER_ARGS["pullback_pct_max"]),
+            value=int(DEFAULT_FILTER_ARGS["pullback_pct_max"]),
+            step=1,
         )
     with col_b:
         max_price = st.number_input(
             "Max Price",
-            value=float(DEFAULT_FILTER_ARGS["max_price"]),
+            value=int(DEFAULT_FILTER_ARGS["max_price"]),
+            step=1,
         )
         max_atr_pct = st.number_input(
             "Max ATR %",
-            value=float(DEFAULT_FILTER_ARGS["max_atr_pct"]),
+            value=int(DEFAULT_FILTER_ARGS["max_atr_pct"]),
+            step=1,
         )
         below_sma = st.selectbox(
             "Below SMA",
@@ -115,11 +124,13 @@ with st.expander("Indicator Filters"):
         )
         min_gap_pct = st.number_input(
             "Min Gap %",
-            value=float(DEFAULT_FILTER_ARGS["min_gap_pct"]),
+            value=int(DEFAULT_FILTER_ARGS["min_gap_pct"]),
+            step=1,
         )
         lower_wick_max = st.number_input(
             "Lower Wick % Max",
-            value=float(DEFAULT_FILTER_ARGS["lower_wick_max"]),
+            value=int(DEFAULT_FILTER_ARGS["lower_wick_max"]),
+            step=1,
         )
 
     filter_args = build_filter_args(

--- a/backtest_filters.py
+++ b/backtest_filters.py
@@ -38,20 +38,20 @@ INDICATOR_CHOICES = [
 # ``build_filter_args`` to create a ``argparse.Namespace`` with these defaults
 # and selectively override values as needed.
 DEFAULT_FILTER_ARGS: dict[str, float | int] = {
-    "min_price": 5.0,
-    "max_price": 200.0,
+    "min_price": 5,
+    "max_price": 200,
     "min_avg_vol": 1_000_000,
     "min_dollar_vol": 20_000_000,
-    "min_atr_pct": 1.0,
-    "max_atr_pct": 8.0,
+    "min_atr_pct": 1,
+    "max_atr_pct": 8,
     "above_sma": 20,
     "below_sma": 20,
-    "trend_slope": 0.0,
-    "min_gap_pct": 0.4,
-    "body_pct_min": 60.0,
-    "upper_wick_max": 30.0,
-    "lower_wick_max": 40.0,
-    "pullback_pct_max": 6.0,
+    "trend_slope": 0,
+    "min_gap_pct": 1,
+    "body_pct_min": 60,
+    "upper_wick_max": 30,
+    "lower_wick_max": 40,
+    "pullback_pct_max": 6,
 }
 
 


### PR DESCRIPTION
## Summary
- Use whole-number defaults for Taygetus indicator filters
- Require integer input for indicator filter fields in Taygetus app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5e9fd06108326b37f43e0ee27ac33