### PR TITLE
Assign unique keys to slider buttons

### DIFF
--- a/app/components/numeric_inputs.py
+++ b/app/components/numeric_inputs.py
@@ -50,6 +50,7 @@ def slider_with_input(
         btn_col1, btn_col2 = st.columns(2)
         btn_col1.button(
             "−",
+            key=f"{key}_decrement_button",
             use_container_width=True,
             on_click=lambda: st.session_state.update(
                 {key: _quantize(st.session_state[key] - step, step)}
@@ -57,6 +58,7 @@ def slider_with_input(
         )
         btn_col2.button(
             "+",
+            key=f"{key}_increment_button",
             use_container_width=True,
             on_click=lambda: st.session_state.update(
                 {key: _quantize(st.session_state[key] + step, step)}


### PR DESCRIPTION
## Summary
- add unique Streamlit `key` values to +/- buttons in `slider_with_input`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'altair')*

------
https://chatgpt.com/codex/tasks/task_e_68b60d2aa11883268d082dc3c042478f