### PR TITLE
Prefer period over start/end for Taygetus backtests

### DIFF
--- a/app/pages/3_Taygetus.py
+++ b/app/pages/3_Taygetus.py
@@ -19,6 +19,7 @@ from backtest_filters import (  # noqa: E402
 from portfolio_utils import expand_ticker_args  # noqa: E402
 from stocks.backtests.taygetus_run import run_backtest_for_ticker  # noqa: E402
 from stocks.utils.plots import equity_curve, gain_loss_bar  # noqa: E402
+from stock_functions import period_to_start_end  # noqa: E402
 
 
 @st.cache_data(show_spinner=False)
@@ -58,7 +59,19 @@ with col1:
 with col2:
     end = st.date_input("End", dt.date.today())
 with col3:
-    period = st.text_input("Period", "1y")
+    period_options = [
+        "5d",
+        "1mo",
+        "3mo",
+        "6mo",
+        "1y",
+        "2y",
+        "5y",
+        "10y",
+        "ytd",
+        "max",
+    ]
+    period = st.selectbox("Period", period_options, index=4)
 with col4:
     max_out = st.number_input("Max tickers", min_value=1, value=20)
 pattern = pattern_selector()
@@ -197,11 +210,14 @@ if st.button("Run"):
         if t.strip()
     ]
     tickers = [t.upper() for t in expand_ticker_args(tokens)]
-    start_str = start.strftime("%Y-%m-%d")
-    end_str = end.strftime("%Y-%m-%d")
-    start_ts = pd.Timestamp(start_str)
-    end_ts = pd.Timestamp(end_str)
-    cache_tag = f"{start_str}_{end_str}"
+    if period:
+        start_dt, end_dt = period_to_start_end(period)
+        start_ts = pd.Timestamp(start_dt)
+        end_ts = pd.Timestamp(end_dt)
+    else:
+        start_ts = pd.Timestamp(start)
+        end_ts = pd.Timestamp(end)
+    cache_tag = f"{start_ts.date()}_{end_ts.date()}"
 
     all_trades: list[pd.DataFrame] = []
     ticker_trades: list[tuple[str, pd.DataFrame]] = []

--- a/cli/taygetus_backtest.py
+++ b/cli/taygetus_backtest.py
@@ -19,7 +19,10 @@ def main() -> None:
         )
     parser.add_argument("--start", help="Start date YYYY-MM-DD")
     parser.add_argument("--end", help="End date YYYY-MM-DD")
-    parser.add_argument("--period", help="yfinance period, e.g. 1y")
+    parser.add_argument(
+        "--period",
+        help="yfinance period, e.g. 1y (overrides start/end if both provided)",
+    )
     parser.add_argument("--export", help="Path to export trades as CSV")
     parser.add_argument(
         "--console-out",
@@ -28,9 +31,12 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    df = fetch_ticker(
-        args.ticker, start=args.start, end=args.end, period=args.period
-    )
+    # yfinance ignores ``period`` when ``start``/``end`` are supplied.  For the
+    # CLI we explicitly prefer ``period`` if both are given.
+    if args.period:
+        df = fetch_ticker(args.ticker, period=args.period)
+    else:
+        df = fetch_ticker(args.ticker, start=args.start, end=args.end)
     trades = backtest_pattern(df, args.pattern)
     export_trades(trades, args.export)
 

--- a/taygetusBacktest.py
+++ b/taygetusBacktest.py
@@ -47,9 +47,11 @@ def fetch_current_price(ticker: str) -> float | None:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Taygetus pattern backtest")
     parser.add_argument('ticker', nargs='+', help='Ticker symbol or list of symbols')
-    group = parser.add_mutually_exclusive_group(required=False)
-    group.add_argument('--period', help='yfinance period string (e.g. 1y, 6mo)')
-    group.add_argument('--start', help='Start date YYYY-MM-DD')
+    parser.add_argument(
+        '--period',
+        help='yfinance period string (e.g. 1y, 6mo) (overrides start/end if both provided)'
+    )
+    parser.add_argument('--start', help='Start date YYYY-MM-DD')
     parser.add_argument('--end', help='Last buy date YYYY-MM-DD')
     parser.add_argument(
         '--console-out',
@@ -166,11 +168,15 @@ def main() -> None:
     pat = parse_pattern(args.pattern)
     pattern_length = pat.length + 1
 
-    if args.start:
+    if args.period:
+        start, end = period_to_start_end(args.period)
+        start = pd.to_datetime(start)
+        end = pd.to_datetime(end)
+    elif args.start:
         start = pd.to_datetime(args.start)
         end = pd.to_datetime(args.end) if args.end else pd.Timestamp.now().normalize()
     else:
-        start, end = period_to_start_end(args.period or '1y')
+        start, end = period_to_start_end('1y')
         start = pd.to_datetime(start)
         end = pd.to_datetime(end)
 


### PR DESCRIPTION
## Summary
- Prefer `period` over explicit start/end dates in Taygetus backtest CLI
- Streamlit Taygetus page offers period dropdown and uses it when provided
- Main Taygetus backtest script now gives period precedence when both args exist

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b61dd042848326a2c3ef7cd97b3730