### PR TITLE
Add Chrome extension redirect for eBay root

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,35 @@
+const TARGET_URL = "https://www.ebay.com/sh/lst/active";
+const EBAY_HOSTS = new Set(["www.ebay.com", "ebay.com"]);
+
+function isRootEbayUrl(urlString) {
+  try {
+    const url = new URL(urlString);
+    const isEbayHost = EBAY_HOSTS.has(url.hostname.toLowerCase());
+
+    if (!isEbayHost) {
+      return false;
+    }
+
+    // Normalize trailing slashes so "/" and "//" both collapse to "/".
+    const normalizedPath = url.pathname.replace(/\/+$/, "/");
+    return normalizedPath === "/";
+  } catch (error) {
+    return false;
+  }
+}
+
+chrome.webNavigation.onCommitted.addListener((details) => {
+  if (details.frameId !== 0) {
+    return; // Only redirect top-level navigations.
+  }
+
+  if (!isRootEbayUrl(details.url)) {
+    return;
+  }
+
+  if (details.url === TARGET_URL) {
+    return; // Already on the destination.
+  }
+
+  chrome.tabs.update(details.tabId, { url: TARGET_URL });
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": 3,
+  "name": "Ebay Redirector",
+  "version": "1.0.0",
+  "description": "Redirects visits to ebay.com to the active listings page.",
+  "permissions": ["tabs", "webNavigation"],
+  "host_permissions": [
+    "https://www.ebay.com/*",
+    "http://www.ebay.com/*",
+    "https://ebay.com/*",
+    "http://ebay.com/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_title": "Ebay Redirector"
+  }
+}


### PR DESCRIPTION
## Summary
- add a Chrome extension manifest and background service worker
- redirect visits to ebay.com root to the Seller Hub active listings page

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e54c36be8832699a2437f324e0721)