### PR TITLE
Add intraday extreme metrics (`avg_max_up_pct`, `avg_max_down_pct`) to gapDetector

### DIFF
--- a/gapDetector.py
+++ b/gapDetector.py
@@ -68,12 +68,16 @@ def analyze_gaps(ticker: str, start: pd.Timestamp, end: pd.Timestamp, tolerance:
             "avg_after_gap_pct": 0.0,
             "avg_after_gap_up_pct": 0.0,
             "avg_after_gap_down_pct": 0.0,
+            "avg_max_up_pct": 0.0,
+            "avg_max_down_pct": 0.0,
         }
 
     df = df.sort_values("Date").copy()
     df["prev_close"] = df["Close"].shift(1)
     df["gap_pct"] = (df["Open"] - df["prev_close"]) / df["prev_close"] * 100
     df["after_gap_pct"] = (df["Close"] - df["Open"]) / df["Open"] * 100
+    df["max_up_pct"] = (df["High"] - df["Open"]) / df["Open"] * 100
+    df["max_down_pct"] = (df["Low"] - df["Open"]) / df["Open"] * 100
 
     in_range = df[
         (df["Date"].dt.date >= start.date())
@@ -98,6 +102,8 @@ def analyze_gaps(ticker: str, start: pd.Timestamp, end: pd.Timestamp, tolerance:
         "avg_after_gap_pct": float(gap_days["after_gap_pct"].mean()) if not gap_days.empty else 0.0,
         "avg_after_gap_up_pct": float(gap_up["after_gap_pct"].mean()) if not gap_up.empty else 0.0,
         "avg_after_gap_down_pct": float(gap_down["after_gap_pct"].mean()) if not gap_down.empty else 0.0,
+        "avg_max_up_pct": float(gap_up["max_up_pct"].mean()) if not gap_up.empty else 0.0,
+        "avg_max_down_pct": float(gap_down["max_down_pct"].mean()) if not gap_down.empty else 0.0,
     }
 
 

--- a/tests/test_gap_detector.py
+++ b/tests/test_gap_detector.py
@@ -1,0 +1,42 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+MODULE_PATH = REPO_ROOT / "gapDetector.py"
+SPEC = importlib.util.spec_from_file_location("gapDetector", MODULE_PATH)
+gapDetector = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(gapDetector)
+
+
+def test_analyze_gaps_reports_intraday_extremes(monkeypatch):
+    data = pd.DataFrame(
+        {
+            "Date": pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03"]),
+            "Open": [100.0, 110.0, 90.0],
+            "High": [101.0, 121.0, 95.0],
+            "Low": [99.0, 105.0, 81.0],
+            "Close": [100.0, 115.0, 85.0],
+        }
+    )
+
+    def fake_fetch_daily_data(ticker, start, end):
+        return data
+
+    monkeypatch.setattr(gapDetector, "fetch_daily_data", fake_fetch_daily_data)
+
+    result = gapDetector.analyze_gaps(
+        "FAKE",
+        pd.Timestamp("2024-01-02"),
+        pd.Timestamp("2024-01-03"),
+        tolerance=0,
+    )
+
+    assert result["gap_up_days"] == 1
+    assert result["gap_down_days"] == 1
+    assert result["avg_max_up_pct"] == 10.0
+    assert result["avg_max_down_pct"] == -10.0


### PR DESCRIPTION
### Motivation
- Report how far prices moved intraday after a gap by adding average open-to-high and open-to-low metrics for gap-up and gap-down days respectively. 
- Preserve CSV/table schema consistency by returning these fields even when no bars are available. 

### Description
- Compute per-row `max_up_pct = (High - Open) / Open * 100` and `max_down_pct = (Low - Open) / Open * 100` in `analyze_gaps` in `gapDetector.py`. 
- Include `avg_max_up_pct` and `avg_max_down_pct` in the function's empty-data return shape and in the final summary dict using averages over `gap_up` and `gap_down` subsets. 
- Add a focused unit test `tests/test_gap_detector.py` that monkeypatches `fetch_daily_data` and asserts expected values for `avg_max_up_pct` and `avg_max_down_pct`. 

### Testing
- Ran `pytest -q tests/test_gap_detector.py`, and the new test passed. 
- Ran full `pytest -q`, which failed during collection due to a missing optional dependency `altair` required by `stocks.utils.plots`, unrelated to the gap metric changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56c4228ae08326b8043c97acef8a4a)