### PR TITLE
Count intraday max moves as gap successes

### DIFF
--- a/gapDetector.py
+++ b/gapDetector.py
@@ -109,10 +109,24 @@ def analyze_gaps(
     gap_count = len(gap_days)
     success = abs(success)
     successful_gap_up_count = (
-        int((gap_up["after_gap_pct"] >= success).sum()) if gap_up_count else 0
+        int(
+            (
+                (gap_up["after_gap_pct"] >= success)
+                | (gap_up["max_up_pct"] >= success * 2)
+            ).sum()
+        )
+        if gap_up_count
+        else 0
     )
     successful_gap_down_count = (
-        int((gap_down["after_gap_pct"] <= -success).sum()) if gap_down_count else 0
+        int(
+            (
+                (gap_down["after_gap_pct"] <= -success)
+                | (gap_down["max_down_pct"] <= -(success * 2))
+            ).sum()
+        )
+        if gap_down_count
+        else 0
     )
     successful_gap_count = successful_gap_up_count + successful_gap_down_count
 


### PR DESCRIPTION
### Motivation
- The existing gap success metric only considered the open-to-close move (`after_gap_pct`), which misses cases where intraday extremes met the target even if the close did not.
- Include strong intraday moves by treating a day as successful when the intraday max move (`max_up_pct`/`max_down_pct`) reaches at least `2x` the configured `success` threshold.

### Description
- Updated `gapDetector.py` to compute `successful_gap_up_count` by counting rows where `(gap_up["after_gap_pct"] >= success) | (gap_up["max_up_pct"] >= success * 2)`.
- Updated `gapDetector.py` to compute `successful_gap_down_count` by counting rows where `(gap_down["after_gap_pct"] <= -success) | (gap_down["max_down_pct"] <= -(success * 2))`.
- Preserved existing handling for zero counts and left all other summary calculations and output behavior unchanged.

### Testing
- Ran `python -m py_compile gapDetector.py` which completed successfully.
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56e1c2c4d483268b543b08e177957c)