### PR TITLE
Add `gapping` report option with extended-hours gap detection

### DIFF
--- a/gapDetector.py
+++ b/gapDetector.py
@@ -2,9 +2,13 @@ import argparse
 from pathlib import Path
 
 import pandas as pd
+import yfinance as yf
 from portfolio_utils import expand_ticker_args
 from backtest_filters import fetch_daily_data as fetch_cached_daily_data
 from stock_functions import period_to_start_end, round_numeric_cols
+
+REGULAR_MARKET_OPEN = pd.Timestamp("09:30").time()
+REGULAR_MARKET_CLOSE = pd.Timestamp("16:00").time()
 
 try:
     from tabulate import tabulate
@@ -49,6 +53,74 @@ def fetch_daily_data(
     df = flatten_yfinance_columns(df)
     df["Date"] = pd.to_datetime(df["Date"]).dt.tz_localize(None)
     return df
+
+
+def is_regular_market_time(timestamp: pd.Timestamp) -> bool:
+    """Return True when *timestamp* falls inside regular US market hours."""
+    ts = pd.Timestamp(timestamp)
+    # yfinance returns exchange-local timestamps for this history call, so use the
+    # timestamp's displayed wall-clock time instead of requiring local tzdata.
+    market_time = ts.time()
+    return REGULAR_MARKET_OPEN <= market_time <= REGULAR_MARKET_CLOSE
+
+
+def fetch_current_extended_gap(ticker: str) -> dict[str, float | str] | None:
+    """Return the current extended-hours gap for *ticker*, if available."""
+    history = yf.Ticker(ticker).history(
+        period="5d", interval="1m", prepost=True, auto_adjust=False
+    )
+    if history.empty or "Close" not in history.columns:
+        return None
+
+    history = flatten_yfinance_columns(history).dropna(subset=["Close"]).copy()
+    if history.empty:
+        return None
+
+    if not isinstance(history.index, pd.DatetimeIndex):
+        history.index = pd.to_datetime(history.index)
+
+    latest_row = history.iloc[-1]
+    latest_timestamp = pd.Timestamp(history.index[-1])
+    if is_regular_market_time(latest_timestamp):
+        return None
+
+    regular_rows = history[
+        history.index.map(is_regular_market_time) & (history.index < latest_timestamp)
+    ]
+    if regular_rows.empty:
+        return None
+
+    previous_close = float(regular_rows.iloc[-1]["Close"])
+    latest_price = float(latest_row["Close"])
+    if previous_close == 0:
+        return None
+
+    current_gap_pct = (latest_price - previous_close) / previous_close * 100
+    direction = "up" if current_gap_pct > 0 else "down" if current_gap_pct < 0 else "flat"
+    return {
+        "ticker": ticker,
+        "current_gap_pct": current_gap_pct,
+        "current_extended_price": latest_price,
+        "previous_regular_close": previous_close,
+        "current_gap_direction": direction,
+        "current_extended_timestamp": latest_timestamp.isoformat(),
+    }
+
+
+def current_gapping_tickers(
+    tickers: list[str], tolerance: float
+) -> dict[str, dict[str, float | str]]:
+    """Return tickers whose latest extended-hours quote exceeds *tolerance*."""
+    min_gap = abs(tolerance)
+    gapping = {}
+    for ticker in tickers:
+        gap = fetch_current_extended_gap(ticker)
+        if gap is None:
+            continue
+        current_gap_pct = float(gap["current_gap_pct"])
+        if (min_gap == 0 and current_gap_pct != 0) or abs(current_gap_pct) >= min_gap:
+            gapping[ticker] = gap
+    return gapping
 
 
 def analyze_gaps(
@@ -216,6 +288,13 @@ def filter_report_columns(summary: pd.DataFrame, report: str) -> pd.DataFrame:
         "avg_after_gap_pct",
         "success_both_pct",
     ]
+    current_gap_columns = [
+        "current_gap_pct",
+        "current_extended_price",
+        "previous_regular_close",
+        "current_gap_direction",
+        "current_extended_timestamp",
+    ]
 
     if report == "up":
         columns = shared_columns + up_columns
@@ -224,7 +303,8 @@ def filter_report_columns(summary: pd.DataFrame, report: str) -> pd.DataFrame:
     else:
         columns = shared_columns + up_columns + down_columns + both_columns
 
-    return summary[columns]
+    columns += [column for column in current_gap_columns if column in summary.columns]
+    return summary.reindex(columns=columns)
 
 
 def main() -> None:
@@ -258,9 +338,12 @@ def main() -> None:
     )
     parser.add_argument(
         "--report",
-        choices=("up", "down", "both"),
+        choices=("up", "down", "both", "gapping"),
         default="both",
-        help="Gap direction data to report (default: both)",
+        help=(
+            "Gap direction data to report. Use gapping to first limit analysis to "
+            "tickers currently gapping in premarket or after-hours data (default: both)."
+        ),
     )
     parser.add_argument(
         "--csv-out",
@@ -271,11 +354,22 @@ def main() -> None:
     tickers = expand_ticker_args(args.ticker)
     start, end = parse_date_range(args.period, args.start, args.end)
     cache_tag = f"{start.date()}_{end.date()}"
+    current_gaps = {}
+    report = args.report
+    if report == "gapping":
+        current_gaps = current_gapping_tickers(tickers, args.tolerance)
+        tickers = list(current_gaps)
+        report = "both"
+
     rows = [
         analyze_gaps(ticker, start, end, args.tolerance, args.success, cache_tag)
         for ticker in tickers
     ]
-    summary = filter_report_columns(round_numeric_cols(pd.DataFrame(rows)), args.report)
+    summary = round_numeric_cols(pd.DataFrame(rows))
+    if current_gaps and not summary.empty:
+        current_gap_summary = pd.DataFrame(current_gaps.values())
+        summary = summary.merge(current_gap_summary, on="ticker", how="left")
+    summary = filter_report_columns(summary, report)
 
     if tabulate:
         print(tabulate(summary, headers="keys", tablefmt="grid", showindex=False))

--- a/tests/test_gap_detector.py
+++ b/tests/test_gap_detector.py
@@ -24,7 +24,7 @@ def test_analyze_gaps_reports_intraday_extremes(monkeypatch):
         }
     )
 
-    def fake_fetch_daily_data(ticker, start, end):
+    def fake_fetch_daily_data(ticker, start, end, cache_tag):
         return data
 
     monkeypatch.setattr(gapDetector, "fetch_daily_data", fake_fetch_daily_data)
@@ -34,9 +34,57 @@ def test_analyze_gaps_reports_intraday_extremes(monkeypatch):
         pd.Timestamp("2024-01-02"),
         pd.Timestamp("2024-01-03"),
         tolerance=0,
+        success=0,
+        cache_tag="test",
     )
 
     assert result["gap_up_days"] == 1
     assert result["gap_down_days"] == 1
     assert result["avg_max_up_pct"] == 10.0
     assert result["avg_max_down_pct"] == -10.0
+
+
+def test_fetch_current_extended_gap_uses_latest_extended_price(monkeypatch):
+    history = pd.DataFrame(
+        {"Close": [100.0, 102.0, 105.0]},
+        index=pd.to_datetime(
+            [
+                "2024-01-02 15:59",
+                "2024-01-02 16:00",
+                "2024-01-02 16:30",
+            ]
+        ),
+    )
+
+    class FakeTicker:
+        def __init__(self, ticker):
+            self.ticker = ticker
+
+        def history(self, **kwargs):
+            assert kwargs["prepost"] is True
+            return history
+
+    monkeypatch.setattr(gapDetector.yf, "Ticker", FakeTicker)
+
+    result = gapDetector.fetch_current_extended_gap("FAKE")
+
+    assert result["ticker"] == "FAKE"
+    assert result["current_gap_pct"] == 2.941176470588235
+    assert result["current_gap_direction"] == "up"
+
+
+def test_current_gapping_tickers_filters_by_absolute_tolerance(monkeypatch):
+    gaps = {
+        "UP": {"ticker": "UP", "current_gap_pct": 2.0},
+        "DOWN": {"ticker": "DOWN", "current_gap_pct": -1.5},
+        "FLAT": {"ticker": "FLAT", "current_gap_pct": 0.5},
+    }
+
+    monkeypatch.setattr(
+        gapDetector, "fetch_current_extended_gap", lambda ticker: gaps[ticker]
+    )
+
+    assert list(gapDetector.current_gapping_tickers(["UP", "DOWN", "FLAT"], 1.0)) == [
+        "UP",
+        "DOWN",
+    ]


### PR DESCRIPTION
### Motivation
- Provide an option to limit gap reports to tickers that are currently gapping in pre-market or after-hours trading using the latest available quotes. 
- Surface current extended-hours gap metadata alongside the historical gap summary so users can see live gap direction and size.

### Description
- Added `fetch_current_extended_gap` to pull recent 1-minute pre/post-market history from `yfinance` and compute the latest extended-hours gap versus the most recent regular-session close. 
- Added `current_gapping_tickers` to filter a ticker list to those whose latest extended-hours gap exceeds `--tolerance` (absolute). 
- Added `--report gapping` CLI choice which first limits the ticker set to currently gapping tickers, then runs the historical `analyze_gaps` report on that filtered set. 
- Included current gap columns (`current_gap_pct`, `current_extended_price`, `previous_regular_close`, `current_gap_direction`, `current_extended_timestamp`) in the output merge and report column filtering, and adjusted `is_regular_market_time` to use wall-clock times to avoid requiring system tzdata.

### Testing
- Ran unit tests for the gap detector with `pytest -q tests/test_gap_detector.py`, which passed. 
- Verified the modified module compiles with `python -m py_compile gapDetector.py`, which succeeded. 
- Ran the full test suite with `pytest -q`, which was blocked by a missing optional environment dependency (`altair`) unrelated to the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56e5aefea08326b681d5ab2c01327b)