### PR TITLE
Add direction-specific extended-hours gap filters and report modes

### DIFF
--- a/gapDetector.py
+++ b/gapDetector.py
@@ -96,7 +96,9 @@ def fetch_current_extended_gap(ticker: str) -> dict[str, float | str] | None:
         return None
 
     current_gap_pct = (latest_price - previous_close) / previous_close * 100
-    direction = "up" if current_gap_pct > 0 else "down" if current_gap_pct < 0 else "flat"
+    direction = (
+        "up" if current_gap_pct > 0 else "down" if current_gap_pct < 0 else "flat"
+    )
     return {
         "ticker": ticker,
         "current_gap_pct": current_gap_pct,
@@ -107,20 +109,32 @@ def fetch_current_extended_gap(ticker: str) -> dict[str, float | str] | None:
     }
 
 
-def current_gapping_tickers(
-    tickers: list[str], tolerance: float
+def current_gap_tickers(
+    tickers: list[str], tolerance: float, direction: str
 ) -> dict[str, dict[str, float | str]]:
-    """Return tickers whose latest extended-hours quote exceeds *tolerance*."""
+    """Return tickers currently gapping in the requested extended-hours direction."""
     min_gap = abs(tolerance)
-    gapping = {}
+    if direction not in {"up", "down"}:
+        raise ValueError("direction must be 'up' or 'down'")
+
+    current_gaps = {}
     for ticker in tickers:
         gap = fetch_current_extended_gap(ticker)
         if gap is None:
             continue
         current_gap_pct = float(gap["current_gap_pct"])
-        if (min_gap == 0 and current_gap_pct != 0) or abs(current_gap_pct) >= min_gap:
-            gapping[ticker] = gap
-    return gapping
+        meets_tolerance = (
+            current_gap_pct >= min_gap
+            if direction == "up"
+            else current_gap_pct <= -min_gap
+        )
+        if min_gap == 0:
+            meets_tolerance = (
+                current_gap_pct > 0 if direction == "up" else current_gap_pct < 0
+            )
+        if meets_tolerance:
+            current_gaps[ticker] = gap
+    return current_gaps
 
 
 def analyze_gaps(
@@ -338,11 +352,12 @@ def main() -> None:
     )
     parser.add_argument(
         "--report",
-        choices=("up", "down", "both", "gapping"),
+        choices=("up", "down", "both", "gap_up", "gap_down"),
         default="both",
         help=(
-            "Gap direction data to report. Use gapping to first limit analysis to "
-            "tickers currently gapping in premarket or after-hours data (default: both)."
+            "Gap direction data to report. Use gap_up or gap_down to first limit "
+            "analysis to tickers currently gapping in that direction in premarket "
+            "or after-hours data (default: both)."
         ),
     )
     parser.add_argument(
@@ -356,10 +371,13 @@ def main() -> None:
     cache_tag = f"{start.date()}_{end.date()}"
     current_gaps = {}
     report = args.report
-    if report == "gapping":
-        current_gaps = current_gapping_tickers(tickers, args.tolerance)
+    if report in {"gap_up", "gap_down"}:
+        current_gap_direction = "up" if report == "gap_up" else "down"
+        current_gaps = current_gap_tickers(
+            tickers, args.tolerance, current_gap_direction
+        )
         tickers = list(current_gaps)
-        report = "both"
+        report = current_gap_direction
 
     rows = [
         analyze_gaps(ticker, start, end, args.tolerance, args.success, cache_tag)

--- a/tests/test_gap_detector.py
+++ b/tests/test_gap_detector.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pandas as pd
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 MODULE_PATH = REPO_ROOT / "gapDetector.py"
@@ -73,7 +72,7 @@ def test_fetch_current_extended_gap_uses_latest_extended_price(monkeypatch):
     assert result["current_gap_direction"] == "up"
 
 
-def test_current_gapping_tickers_filters_by_absolute_tolerance(monkeypatch):
+def test_current_gap_tickers_filters_by_direction_and_tolerance(monkeypatch):
     gaps = {
         "UP": {"ticker": "UP", "current_gap_pct": 2.0},
         "DOWN": {"ticker": "DOWN", "current_gap_pct": -1.5},
@@ -84,7 +83,11 @@ def test_current_gapping_tickers_filters_by_absolute_tolerance(monkeypatch):
         gapDetector, "fetch_current_extended_gap", lambda ticker: gaps[ticker]
     )
 
-    assert list(gapDetector.current_gapping_tickers(["UP", "DOWN", "FLAT"], 1.0)) == [
+    assert list(gapDetector.current_gap_tickers(["UP", "DOWN", "FLAT"], 1.0, "up")) == [
         "UP",
+    ]
+    assert list(
+        gapDetector.current_gap_tickers(["UP", "DOWN", "FLAT"], 1.0, "down")
+    ) == [
         "DOWN",
     ]


### PR DESCRIPTION
### Motivation
- Replace the generic `gapping` report option with explicit direction-specific modes so users can limit analysis to tickers currently gapping only up or only down in extended hours.
- Make current extended-hours filtering apply to a single direction (up or down) rather than both, enabling clearer directional reports and thresholds.

### Description
- Introduced `current_gap_tickers(tickers, tolerance, direction)` to replace the previous non-directional helper and validate `direction` is `"up"` or `"down"` while applying directional tolerance logic using `>= min_gap` for up and `<= -min_gap` for down.
- Added CLI `--report` choices `"gap_up"` and `"gap_down"` and updated help text to describe direction-specific premarket/after-hours filtering.
- Wired `gap_up` / `gap_down` report modes to call `current_gap_tickers(...)`, reduce the ticker list to matching current gaps, and then run the directional historical report (`report` becomes `"up"` or `"down"`).
- Updated `tests/test_gap_detector.py` to exercise the new `current_gap_tickers` behavior and assert both upward and downward filtering, and reformatted files with `black`.

### Testing
- Ran code formatting with `python -m black gapDetector.py tests/test_gap_detector.py`, which completed successfully.
- Ran unit tests with `pytest tests/test_gap_detector.py`, which succeeded: `3 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56e734e48083268dbaa60120b2b0ee)